### PR TITLE
Travis Build Matrix for old version of deal-ii

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ services:
  - docker
 
 before_install:
- - sudo docker pull DEALII
+ - sudo docker pull $DEALII
 
 install:
- - sudo docker run DEALII
+ - sudo docker run $DEALII
  - id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
  - sudo docker cp ../BART $id:/home/dealii
  - id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,32 @@
 sudo: required
+
 branches:
   only:
   - master
   - dev
+
 notifications:
   email: false
+
 language: cpp
+
+matrix:
+ include:
+ - env: DEALII=dealii/dealii:v8.4.2-gcc-mpi-fulldepsmanual-debugrelease
+ - env: DEALII=dealii/dealii:v8.5.0-gcc-mpi-fulldepscandi-debugrelease
+
 services:
  - docker
+
 before_install:
- - sudo docker pull dealii/dealii:v8.5.0-gcc-mpi-fulldepscandi-debugrelease
+ - sudo docker pull DEALII
+
 install:
- - sudo docker run dealii/dealii:v8.5.0-gcc-mpi-fulldepscandi-debugrelease
+ - sudo docker run DEALII
  - id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
  - sudo docker cp ../BART $id:/home/dealii
  - id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
  - sudo docker commit $id dealii/dealii-bart
+
 script:
  - sudo docker run dealii/dealii-bart /bin/sh -c "cmake BART/; make"


### PR DESCRIPTION
Adds a build matrix to the travis build that uses the `deal-ii` containers for both `8.4.2` and `8.5.0`.