### PR TITLE
Continuous Integration and testing update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,22 @@ services:
  - docker
 
 before_install:
- - mkdir shared
- - sudo docker pull jsrehak/bart-gtest
+ - sudo docker pull jsrehak/bart
  - ci_env=`bash <(curl -s https://codecov.io/env)`
 
 install:
- - sudo docker run jsrehak/bart-gtest
+ - sudo docker run jsrehak/bart
  - id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
  - sudo docker cp ../BART $id:/home/dealii
  - id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
- - sudo docker commit $id jsrehak/bart-gtest
- - sudo docker run $ci_env -it -u="root" -d -w="/home/dealii/BART" -v "$PWD/shared:/home/dealii/shared" --name bart jsrehak/bart-gtest
+ - sudo docker commit $id jsrehak/bart
+ - sudo docker run $ci_env -it -u="root" -d -w="/home/dealii/BART" --name bart jsrehak/bart
 
 script:
  - docker exec bart cmake .
  - docker exec bart make
  - docker exec bart bash -c "./xtrans_test --gtest_filter=-*MPI*"
- - docker exec bart bash -c "mpirun -np 1 ./xtrans_test --gtest_filter=*MPI*"
+ - docker exec bart bash -c "mpirun -np 1 --allow-run-as-root ./xtrans_test --gtest_filter=*MPI*"
 
 after_success:
  - docker exec bart bash -c "./coverage.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
  - docker exec bart cmake .
  - docker exec bart make
  - docker exec bart bash -c "./xtrans_test --gtest_filter=-*MPI*"
+ - docker exec bart bash -c "mpirun -np 1 ./xtrans_test --gtest_filter=*MPI*"
 
 after_success:
  - docker exec bart bash -c "./coverage.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 script:
  - docker exec bart cmake .
  - docker exec bart make
- - docker exec bart bash -c "./xtrans_test"
+ - docker exec bart bash -c "./xtrans_test --gtest_filter=-*MPI*"
 
 after_success:
  - docker exec bart bash -c "./coverage.sh"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,8 @@ file(GLOB_RECURSE sources "src/*.cpp" "src/*.cc")
 set(testing_sources ${sources})
 list(FILTER sources EXCLUDE REGEX ".(/tests/).")
 list(FILTER sources EXCLUDE REGEX ".(/test_helpers/).")
+list(FILTER sources EXCLUDE REGEX "test_main.cc")
+list(FILTER testing_sources EXCLUDE REGEX "main.cc")
 
 # Include directories
 include_directories(${GTEST_INCLUDE_DIRS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 PROJECT(xtrans)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 ### DEPENDENCIES #####################################################
 # Check that DEAL II is installed

--- a/src/aqdata/tests/aq_base_test.cc
+++ b/src/aqdata/tests/aq_base_test.cc
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "gtest/gtest.h"
+#include "../../test_helpers/gmock_wrapper.h"
 #include "../../test_helpers/bart_test_helper.h"
 
 class AQBaseTest : public ::testing::Test {
@@ -130,14 +131,14 @@ TEST_F(AQBaseTest, PrintAQ) {
   std::ostringstream output_string_stream;
   test_AQ.PrintAQ(&output_string_stream);
 
-  std::string output = "transport model: regular; output_streamature name: None\n"
-                       "Dim = 1, SN order = 4\n"
-                       "Weights | Omega_x | Omega_y | mu\n"
-                       "0.347854845137454  -0.861136311594053  \n"
-                       "0.652145154862546  -0.339981043584856  \n"
-                       "0.652145154862546  0.339981043584856  \n"
-                       "0.347854845137454  0.861136311594052  \n"; 
-  EXPECT_EQ(output, output_string_stream.str());
+  std::string output_regex = "transport model: regular; output_streamature name: None\n"
+                             "Dim = 1, SN order = 4\n"
+                             "Weights | Omega_x | Omega_y | mu\n"
+                             "0.34785//d*  -0.86113//d*  \n"
+                             "0.65214//d*  -0.33998//d*  \n"
+                             "0.65214//d*  0.33998//d*  \n"
+                             "0.34785//d*  0.86113//d*  \n";
+  EXPECT_THAT(output_string_stream.str(), ::testing::ContainsRegex(output_regex));
 }
   
 TEST_F(AQBaseTest, RefDirInt) {

--- a/src/common/tests/computing_data_test.cc
+++ b/src/common/tests/computing_data_test.cc
@@ -2,7 +2,7 @@
 #include "../problem_definition.h"
 #include "../../test_helpers/bart_test_helper.h"
 
-class ComputingDataTest
+class ComputingDataTestMPI
     :
     public btest::BARTParallelEnvironment {
  public:
@@ -11,7 +11,7 @@ class ComputingDataTest
   dealii::ParameterHandler prm_;
 };
 
-void ComputingDataTest::SetUp() {
+void ComputingDataTestMPI::SetUp() {
   // Initilize MPI
   this->MPIInit();
   // declare all entries for parameter handler
@@ -22,6 +22,6 @@ void ComputingDataTest::SetUp() {
   prm_.set ("number of cells for x, y, z directions", "1, 3");
 }
 
-TEST_F (ComputingDataTest, 2DFundamentalDataTest) {
+TEST_F (ComputingDataTestMPI, 2DFundamentalDataTest) {
   dealii::parallel::distributed::Triangulation<2> tria_2d(MPI_COMM_WORLD);
 }

--- a/src/equation/even_parity.cc
+++ b/src/equation/even_parity.cc
@@ -222,7 +222,7 @@ void EvenParity<dim>::IntegrateScatteringLinearForm (
   for (int gin=0; gin<this->n_group_; ++gin) {
     std::vector<double> local_flx (this->n_q_);
     this->fv_->get_function_values (
-        this->mat_vec_->moments[this->equ_name_][{gin, 0, 0}], local_flx);
+        this->mat_vec_->moments[this->equ_name_][std::make_tuple(gin, 0, 0)], local_flx);
     for (int qi=0; qi<this->n_q_; ++qi)
       q_at_qp[qi] += (this->xsec_->sigs_per_ster.at(mid)(gin,g) *
                       local_flx[qi]);
@@ -254,7 +254,7 @@ void EvenParity<dim>::IntegrateCellFixedLinearForm (
     {
       std::vector<double> local_flx (this->n_q_);
       this->fv_->get_function_values (
-          this->mat_vec_->moments[this->equ_name_][{gin, 0, 0}], local_flx);
+          this->mat_vec_->moments[this->equ_name_][std::make_tuple(gin, 0, 0)], local_flx);
       for (int qi=0; qi<this->n_q_; ++qi)
         q_at_qp[qi] += this->scaled_fiss_transfer_.at(mid)(gin, g) *
             local_flx[qi];

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,10 +3,16 @@
 #include <getopt.h>
 
 #include <deal.II/base/mpi.h>
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+#include "test_helpers/gmock_wrapper.h"
 #include "test_helpers/bart_test_helper.h"
 #else
+
+#include <iostream>
+
+#include <deal.II/base/parameter_handler.h>
+
 #include "common/problem_definition.h"
 #include "common/bart_driver.h"
 #endif
@@ -47,7 +53,8 @@ int main(int argc, char* argv[]) {
     }
     ParameterHandler prm;
     bparams::DeclareParameters (prm);
-    prm.read_input(argv[1]);
+    const std::string filename{argv[1]};
+    prm.parse_input(filename);
     dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
     int dim = prm.get_integer ("problem dimension");
     switch (dim) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,51 +1,11 @@
-#ifdef TEST
-#include <unistd.h>
-#include <getopt.h>
-
-#include <deal.II/base/mpi.h>
-#include "gtest/gtest.h"
-
-#include "test_helpers/gmock_wrapper.h"
-#include "test_helpers/bart_test_helper.h"
-#else
-
 #include <iostream>
 
 #include <deal.II/base/parameter_handler.h>
 
 #include "common/problem_definition.h"
 #include "common/bart_driver.h"
-#endif
-
-
 
 int main(int argc, char* argv[]) {
-#ifdef TEST
-  // Parse optional arguments
-  ::testing::InitGoogleMock(&argc, argv);
-
-  int option_index = 0;
-
-  const struct option longopts[] =
-  {
-    {"report", no_argument, nullptr, 'r'}
-  };
-
-  int c;
-  while ((c = getopt_long (argc, argv, "rd:", longopts, &option_index)) != -1) {
-    switch(c) {
-      case 'r':
-        btest::GlobalBARTTestHelper().SetReport(true);
-        break;
-      case 'd':
-        btest::GlobalBARTTestHelper().SetGoldFilesDirectory(optarg);
-        break;
-      default:
-        break;
-    }
-  }
-  return RUN_ALL_TESTS();
-#else
   try {
     if (argc!=2) {
       std::cerr << "Call the program as mpirun -np num_proc xtrans input_file_name" << std::endl;
@@ -99,5 +59,4 @@ int main(int argc, char* argv[]) {
     return 1;
   }
   return 0;
-#endif
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -14,7 +14,7 @@ int main(int argc, char* argv[]) {
     ParameterHandler prm;
     bparams::DeclareParameters (prm);
     const std::string filename{argv[1]};
-    prm.parse_input(filename);
+    prm.parse_input(filename, "");
     dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
     int dim = prm.get_integer ("problem dimension");
     switch (dim) {

--- a/src/test_helpers/gmock_wrapper.h
+++ b/src/test_helpers/gmock_wrapper.h
@@ -1,0 +1,25 @@
+#ifndef BART_SRC_TEST_HELPERS_GMOCK_WRAPPER_H_
+#define BART_SRC_TEST_HELPERS_GMOCK_WRAPPER_H_
+
+/*
+  deal.II defines a global Assert() macro that clashes with a
+  gmock_internal_utils function.
+  We want to keep the Assert macro out of
+  gmock/internal/gmock-internal-utils.h, but still have it
+  available for internal use by any deal.II file that may be
+  included after this file.
+  
+  If Assert is defined, save its value, undefine it, include gmock, and
+  redefine it; Else, simply include gmock.
+*/
+
+#ifdef Assert
+#pragma push_macro("Assert")
+#undef Assert
+#include "gmock/gmock.h"
+#pragma pop_macro("Assert")
+#else
+#include "gmock/gmock.h"
+#endif /*ifdef Assert*/
+
+#endif // BART_SRC_TEST_HELPERS_GMOCK_WRAPPER_H_

--- a/src/test_main.cc
+++ b/src/test_main.cc
@@ -1,0 +1,36 @@
+#include <unistd.h>
+#include <getopt.h>
+
+#include <deal.II/base/mpi.h>
+#include "gtest/gtest.h"
+
+#include "test_helpers/gmock_wrapper.h"
+#include "test_helpers/bart_test_helper.h"
+
+int main(int argc, char* argv[]) {
+  // Parse optional arguments
+  ::testing::InitGoogleMock(&argc, argv);
+
+  int option_index = 0;
+
+  const struct option longopts[] =
+  {
+    {"report", no_argument, nullptr, 'r'}
+  };
+
+  int c;
+  while ((c = getopt_long (argc, argv, "rd:", longopts, &option_index)) != -1) {
+    switch(c) {
+      case 'r':
+        btest::GlobalBARTTestHelper().SetReport(true);
+        break;
+      case 'd':
+        btest::GlobalBARTTestHelper().SetGoldFilesDirectory(optarg);
+        break;
+      default:
+        break;
+    }
+  }
+  return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
This pull request:
- Updates `.travis.yml` to pull the new docker container (jsrehak/bart) that contains deailii 9.0
- Splits `main.cc` into two files, `main.cc` for the main executable, and `test_main.cc` for the testing executable. Closes #95 
- Splits execution of regular tests and MPI tests on travis. Closes #97 
- Adds `gmock` wrapper
- Updated `PrintAQ` test to use regex for string comparison to prevent test failure due to float rounding differences
- Other minor bug fixes: adds `make_tuple` to fix copy-list-initialization error, updates parsing call from `read_input` to `parse_input` in `main`, cmake now automatically generates compile commands