### PR TITLE
Hasher function for unordered maps

### DIFF
--- a/doxygen_config
+++ b/doxygen_config
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT=./src/aqdata ./src/equation ./src/common ./src/iteration ./src/mesh ./src/material ./src/test_helpers
+INPUT=./src/aqdata ./src/equation ./src/common ./src/iteration ./src/mesh ./src/material ./src/test_helpers ./src/utility
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/src/utility/bart_hasher.cc
+++ b/src/utility/bart_hasher.cc
@@ -1,0 +1,26 @@
+#include "bart_hasher.h"
+
+namespace butil {
+
+template <std::size_t array_size>
+std::size_t Hasher::operator()(const std::array<int, array_size> array) const {
+  std::size_t seed = 0;
+  // Iterates over array values and combines their hashed values
+  for (const int val : array)
+    boost::hash_combine(seed, boost::hash_value(val));
+  return seed;
+}
+
+std::size_t Hasher::operator()(const std::vector<int> vector) const {
+    std::size_t seed = 0;
+    // Iterates over vector values and combines their hashed values
+    for (const int val : vector)
+      boost::hash_combine(seed, boost::hash_value(val));
+    return seed;
+}
+
+template std::size_t Hasher::operator()(const std::array<int, 1>) const;
+template std::size_t Hasher::operator()(const std::array<int, 2>) const;
+template std::size_t Hasher::operator()(const std::array<int, 3>) const;
+
+} //namespace butil

--- a/src/utility/bart_hasher.h
+++ b/src/utility/bart_hasher.h
@@ -1,0 +1,35 @@
+#ifndef BART_SRC_UTILITY_BART_HASHER_H_
+#define BART_SRC_UTILITY_BART_HASHER_H_
+
+#include <utility>
+#include <tuple>
+#include <vector>
+
+#include <boost/functional/hash.hpp>
+
+//! This namespace provides various utility functions for BART.
+namespace butil {
+
+//! Hashing struct for array<int> of any size, and vector<int>.
+/*! Provides a hashing struct for array<int> of any size, and vector<int>;
+ *  Suitable for use in an unordered_map. Uses the hashing functions of the boost
+ *  library.
+ *  Example:
+ *    std::unordered_map<array<int, 2>, std::string, butil::Hasher> map =
+ *      {{0, 0}, "all zeros"},
+ *      {{1, 1}, "all ones"},};
+ *    std::string value = map[{1,1}]; // Value is "all ones"
+ */    
+
+struct Hasher {
+  //! Converts an array<int, array_size> into a hashed value.
+  template <std::size_t array_size>
+  std::size_t operator()(const std::array<int, array_size>) const;
+  
+  //! Converts a vector<int> into a hashed value.
+  std::size_t operator()(const std::vector<int>) const;
+};
+
+} //namespace butil
+
+#endif

--- a/src/utility/bart_hasher.h
+++ b/src/utility/bart_hasher.h
@@ -7,7 +7,7 @@
 
 #include <boost/functional/hash.hpp>
 
-//! This namespace provides various utility functions for BART.
+//! Provides various utility functions for BART.
 namespace butil {
 
 //! Hashing struct for array<int> of any size, and vector<int>.
@@ -15,10 +15,28 @@ namespace butil {
  *  Suitable for use in an unordered_map. Uses the hashing functions of the boost
  *  library.
  *  Example:
- *    std::unordered_map<array<int, 2>, std::string, butil::Hasher> map =
- *      {{0, 0}, "all zeros"},
- *      {{1, 1}, "all ones"},};
- *    std::string value = map[{1,1}]; // Value is "all ones"
+ *  ~~~~~~~~~~{.cpp}
+ *  #include "bart_hasher.h"
+ *  #include <array>
+ *  #include <iostream>
+ *  #include <string>
+ *  #include <unordered_map>
+ *
+ *  int main()
+ *  {
+ *    std::unordered_map<std::array<int, 2>, std::string, butil::Hasher> map = {
+ *      {{0,0}, "all zeros"},
+ *      {{1,1}, "all ones"}
+ *    };
+ *    std::cout << map[{1,1}] << "\n" << map[{0,0}] << std::endl;
+ *    return 0;
+ *  }
+ *  ~~~~~~~~~~
+ *  Output:
+ *  ~~~~~~~~~~
+ *  all ones
+ *  all zeros
+ *  ~~~~~~~~~~
  */    
 
 struct Hasher {

--- a/src/utility/bart_hasher.h
+++ b/src/utility/bart_hasher.h
@@ -24,11 +24,13 @@ namespace butil {
  *
  *  int main()
  *  {
- *    std::unordered_map<std::array<int, 2>, std::string, butil::Hasher> map = {
- *      {{0,0}, "all zeros"},
- *      {{1,1}, "all ones"}
- *    };
- *    std::cout << map[{1,1}] << "\n" << map[{0,0}] << std::endl;
+ *    std::unordered_map<std::array<int, 2>, std::string, butil::Hasher>
+ *      array_to_string_umap = {
+ *                              {{0,0}, "all zeros"},
+ *                              {{1,1}, "all ones"}
+ *                             };
+ *    std::cout << array_to_string_umap[{1,1}] << "\n"
+ *              << array_to_string_umap[{0,0}] << std::endl;
  *    return 0;
  *  }
  *  ~~~~~~~~~~

--- a/src/utility/tests/bart_hasher_test.cc
+++ b/src/utility/tests/bart_hasher_test.cc
@@ -1,0 +1,23 @@
+#include "../bart_hasher.h"
+
+#include <gtest/gtest.h>
+#include <string>
+
+class BartHasherTest : public ::testing::Test {
+ protected:
+  butil::Hasher test_hasher;
+};
+
+TEST_F(BartHasherTest, ArrayTest) {
+  std::array<int, 2> test_array{1,2};
+  std::size_t result(test_hasher(test_array));
+  std::string hash{"3370697991563800380"};
+  EXPECT_EQ(std::to_string(result), hash);
+}
+
+TEST_F(BartHasherTest, VectorTest) {
+  std::vector<int> test_vector{1,2};
+  std::size_t result(test_hasher(test_vector));
+  std::string hash{"3370697991563800380"};
+  EXPECT_EQ(std::to_string(result), hash);
+}


### PR DESCRIPTION
Adds a `struct` that provides hashing for `std::array<int, n>` and `std::vector<int>` containers, enabling their use as keys in `std::unordered_map` objects.