### PR TITLE
SAAF CFEM Formulation

### DIFF
--- a/reg-test/t-ep_readable.material
+++ b/reg-test/t-ep_readable.material
@@ -1,0 +1,36 @@
+full_name: "T-EP Material"
+abbreviation: "t_ep_mat"
+id: "t_ep_material"
+number_of_groups: 1
+thermal_groups: 1
+vector_property {
+  id: ENERGY_GROUPS
+  value: 20000000.0
+  value: 0.0
+}
+vector_property {
+  id: SIGMA_T
+  value: 1.0
+}
+
+vector_property {
+  id: NU_SIG_F
+  value: 0.99
+}
+
+vector_property {
+  id: Q
+  value: 0
+}
+
+vector_property {
+  id: CHI
+  value: 1
+}
+  
+matrix_property {
+  id: SIGMA_S
+  rows: 1
+  cols: 1
+  value: 0.15
+}

--- a/reg-test/t-saaf
+++ b/reg-test/t-saaf
@@ -1,0 +1,36 @@
+set problem dimension                        = 2
+set angular quadrature name                  = lsgc
+set transport model                          = saaf
+set do print angular quadrature info         = true
+set angular quadrature order                 = 8
+set number of groups                         = 1
+set do eigenvalue calculations               = true
+set do nda                                   = false
+set have reflective boundary                 = false
+#set reflective boundary names                =  xmax, ymax, xmin, ymin
+
+set uniform refinements                      = 3
+
+set ho linear solver name                    = direct
+set ho preconditioner name                   = bssor
+#set ho ssor factor                             = 1.6
+
+
+set x, y, z max values of boundary locations = 10.0, 10.0, 1.0
+set number of cells for x, y, z directions   = 3, 2, 2
+set number of materials                      = 2
+
+set ho spatial discretization                = cfem
+
+set finite element polynomial degree         = 1
+
+set output file name base                    = rhlf
+
+subsection material ID map
+set material id file name map                = 1: t-ep.material, 2: t-ep.material
+set material id file name                    = mid.txt
+end
+
+subsection fissile material IDs
+set fissile material ids                     = 1, 2
+end

--- a/reg-test/t-saaf
+++ b/reg-test/t-saaf
@@ -24,7 +24,7 @@ set ho spatial discretization                = cfem
 
 set finite element polynomial degree         = 1
 
-set output file name base                    = rhlf
+set output file name base                    = saaf_reg_test
 
 subsection material ID map
 set material id file name map                = 1: t-ep.material, 2: t-ep.material

--- a/reg-test/t-saaf-refl
+++ b/reg-test/t-saaf-refl
@@ -7,8 +7,7 @@ set number of groups                         = 1
 set do eigenvalue calculations               = true
 set do nda                                   = false
 set have reflective boundary                 = true
-#set reflective boundary names                =  xmax
-set reflective boundary names                =  xmax, ymax, xmin, ymin
+set reflective boundary names                =  xmax, xmin, ymax, ymin
 
 set uniform refinements                      = 3
 

--- a/reg-test/t-saaf-refl
+++ b/reg-test/t-saaf-refl
@@ -7,13 +7,13 @@ set number of groups                         = 1
 set do eigenvalue calculations               = true
 set do nda                                   = false
 set have reflective boundary                 = true
-set reflective boundary names                =  xmax
-#set reflective boundary names                =  xmax, ymax, xmin, ymin
+#set reflective boundary names                =  xmax
+set reflective boundary names                =  xmax, ymax, xmin, ymin
 
 set uniform refinements                      = 3
 
 set ho linear solver name                    = direct
-set ho preconditioner name                   = bssor
+set ho preconditioner name                   = jacobi
 #set ho ssor factor                             = 1.6
 
 
@@ -25,7 +25,7 @@ set ho spatial discretization                = cfem
 
 set finite element polynomial degree         = 1
 
-set output file name base                    = rhlf
+set output file name base                    = saaf_refl_test
 
 subsection material ID map
 set material id file name map                = 1: t-ep.material, 2: t-ep.material

--- a/reg-test/t-saaf-refl
+++ b/reg-test/t-saaf-refl
@@ -1,0 +1,37 @@
+set problem dimension                        = 2
+set angular quadrature name                  = lsgc
+set transport model                          = saaf
+set do print angular quadrature info         = true
+set angular quadrature order                 = 8
+set number of groups                         = 1
+set do eigenvalue calculations               = true
+set do nda                                   = false
+set have reflective boundary                 = true
+set reflective boundary names                =  xmax
+#set reflective boundary names                =  xmax, ymax, xmin, ymin
+
+set uniform refinements                      = 3
+
+set ho linear solver name                    = direct
+set ho preconditioner name                   = bssor
+#set ho ssor factor                             = 1.6
+
+
+set x, y, z max values of boundary locations = 10.0, 10.0, 1.0
+set number of cells for x, y, z directions   = 3, 2, 2
+set number of materials                      = 2
+
+set ho spatial discretization                = cfem
+
+set finite element polynomial degree         = 1
+
+set output file name base                    = rhlf
+
+subsection material ID map
+set material id file name map                = 1: t-ep.material, 2: t-ep.material
+set material id file name                    = mid.txt
+end
+
+subsection fissile material IDs
+set fissile material ids                     = 1, 2
+end

--- a/src/common/bart_builder.cc
+++ b/src/common/bart_builder.cc
@@ -1,6 +1,7 @@
 #include "bart_builder.h"
 #include "../aqdata/lsgc.h"
 #include "../equation/even_parity.h"
+#include "../equation/self_adjoint_angular_flux.h"
 #include "../iteration/power_iteration.h"
 #include "../iteration/gauss_seidel.h"
 #include "../iteration/source_iteration.h"
@@ -108,11 +109,16 @@ std::unordered_map<std::string, std::unique_ptr<EquationBase<dim>>> BuildEqu (
     std::shared_ptr<FundamentalData<dim>> &dat_ptr) {
   std::unordered_map<std::string, std::unique_ptr<EquationBase<dim>>> equ_ptrs;
   const std::string ho_equ_name(prm.get("transport model"));
-  std::unordered_map<std::string, int> mp = {{"ep",0}};
+  std::unordered_map<std::string, int> mp = {{"ep",0}, {"saaf",1}};
   switch (mp[ho_equ_name]) {
     case 0:
       equ_ptrs[ho_equ_name] = std::unique_ptr<EquationBase<dim>>(
           new EvenParity<dim>(ho_equ_name, prm, dat_ptr));
+      break;
+    case 1:
+      equ_ptrs[ho_equ_name] = std::unique_ptr<EquationBase<dim>>(
+          new SelfAdjointAngularFlux<dim>(ho_equ_name, prm, dat_ptr));
+      break;
     default:
       break;
   }

--- a/src/common/problem_definition.cc
+++ b/src/common/problem_definition.cc
@@ -18,7 +18,7 @@ void DeclareParameters (dealii::ParameterHandler &local_prm) {
     local_prm.declare_entry ("problem dimension", "2",
         dealii::Patterns::Integer(), "");
     local_prm.declare_entry ("transport model", "none",
-        dealii::Patterns::Selection("ep|none"),
+        dealii::Patterns::Selection("ep|saaf|none"),
         "valid names such as ep");
     local_prm.declare_entry ("ho linear solver name", "cg",
         dealii::Patterns::Selection("cg|gmres|bicgstab|direct"),

--- a/src/equation/equation_base.h
+++ b/src/equation/equation_base.h
@@ -69,10 +69,10 @@ class EquationBase {
    \return Void.
    */
   virtual void IntegrateBoundaryBilinearForm (
-      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
-      const int &fn,
+      typename dealii::DoFHandler<dim>::active_cell_iterator &,
+      const int &,
       dealii::FullMatrix<double> &cell_matrix,
-      const int &g,
+      const int &,
       const int &dir) = 0;
 
   /*!

--- a/src/equation/even_parity.h
+++ b/src/equation/even_parity.h
@@ -101,7 +101,7 @@ public:
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
       const int &fn,/*face number*/
       dealii::FullMatrix<double> &cell_matrix,
-      const int &g,
+      const int &,
       const int &dir);
 
   /*!

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -12,6 +12,16 @@ SelfAdjointAngularFlux<dim>::SelfAdjointAngularFlux(
  * PUBLIC FUNCTIONS
  * =============================================================================
  */  
+template<int dim>
+void SelfAdjointAngularFlux<dim>::IntegrateCellBilinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      dealii::FullMatrix<double> &cell_matrix,
+      const int &g,
+      const int &dir) {
+
+
+  
+}
 
 template<int dim>
 void SelfAdjointAngularFlux<dim>::IntegrateScatteringLinearForm (
@@ -59,8 +69,8 @@ void SelfAdjointAngularFlux<dim>::IntegrateScatteringLinearForm (
   for (int q = 0; q < n_q_; ++q) {
     cell_scatter_flux[q] *= fv_->JxW(q);
     for (int i = 0; i < dofs_per_cell_; ++i) {
-      cell_rhs += fv_->shape_value(i, q) * cell_scatter_flux[q];
-      cell_rhs +=
+      cell_rhs(i) += fv_->shape_value(i, q) * cell_scatter_flux[q];
+      cell_rhs(i) +=
           omega_[dir] * fv_->shape_grad(i, q) * cell_scatter_over_total_flux[q];
     }
   }

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -21,7 +21,6 @@ void SelfAdjointAngularFlux<dim>::IntegrateBoundaryBilinearForm (
       const int &dir) {
   
   // Get the boundary ID and the normal vector
-  int boundary_id = cell->face(fn)->boundary_id();
   const dealii::Tensor<1, dim> normal_vector = fvf_->normal_vector(0);
 
   double normal_dot_omega = normal_vector * omega_[dir];

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -19,6 +19,26 @@ void SelfAdjointAngularFlux<dim>::IntegrateBoundaryBilinearForm (
       dealii::FullMatrix<double> &cell_matrix,
       const int &g,
       const int &dir) {
+  
+  // Get the boundary ID and the normal vector
+  int boundary_id = cell->face(fn)->boundary_id();
+  const dealii::Tensor<1, dim> normal_vector = fvf_->normal_vector(0);
+
+  double normal_dot_omega = normal_vector * omega_[dir];
+  
+  if (normal_dot_omega > 0) {
+    // Integrate bilinear term
+    for (int q = 0; q < n_q_; ++q) {
+      for (int i = 0; i < dofs_per_cell_; ++i) {
+        for (int j = 0; j < dofs_per_cell_; ++j) {
+          cell_matrix += normal_dot_omega *
+                         fvf_->shape_value(i, q) *
+                         fvf_->shape_value(j, q) *
+                         fvf_->JxW(q);
+        }
+      }
+    }
+  }
 }
 
 template<int dim>

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -45,7 +45,10 @@ void IntegrateBoundaryLinearForm (
       const int &fn,/*face number*/
       dealii::Vector<double> &cell_rhs,
       const int &g,
-      const int &dir) {}
+      const int &dir) {
+  //TODO: Add section for using previous iteration as incident flux
+
+}
 
 template<int dim>
 void SelfAdjointAngularFlux<dim>::IntegrateCellBilinearForm (

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -40,6 +40,13 @@ void SelfAdjointAngularFlux<dim>::IntegrateBoundaryBilinearForm (
   }
 }
 
+void IntegrateBoundaryLinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      const int &fn,/*face number*/
+      dealii::Vector<double> &cell_rhs,
+      const int &g,
+      const int &dir) {}
+
 template<int dim>
 void SelfAdjointAngularFlux<dim>::IntegrateCellBilinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -133,6 +133,7 @@ void SelfAdjointAngularFlux<dim>::IntegrateScatteringLinearForm (
   // Integrate and add both scattering terms
   for (int q = 0; q < n_q_; ++q) {
     cell_scatter_flux[q] *= fv_->JxW(q);
+    cell_scatter_over_total_flux[q] *= fv_->JxW(q);
     for (int i = 0; i < dofs_per_cell_; ++i) {
       // First scattering term
       cell_rhs(i) += fv_->shape_value(i, q) * cell_scatter_flux[q];

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -37,6 +37,14 @@ void SelfAdjointAngularFlux<dim>::IntegrateCellBilinearForm (
 }
 
 template<int dim>
+void SelfAdjointAngularFlux<dim>::IntegrateCellFixedLinearForm (
+    typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+    dealii::Vector<double> &cell_rhs,
+    const int &g,
+    const int &dir) {
+}
+
+template<int dim>
 void SelfAdjointAngularFlux<dim>::IntegrateScatteringLinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
       dealii::Vector<double> &cell_rhs,

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -82,15 +82,8 @@ void SelfAdjointAngularFlux<dim>::IntegrateScatteringLinearForm (
   
   // Iterate over groups to populate cell_scatter_flux
   for (int group_in = 0; group_in < n_group_; ++group_in) {
-    std::vector<double> group_cell_scalar_flux(n_q_);
-    
-    // Get the global scalar flux for the current group
-    auto group_global_scalar_flux =
-        mat_vec_->moments[equ_name_][std::make_tuple(group_in, 0, 0)];
-
-    // Evaluate the global scalar flux at the quadrature points of the current
-    // cell and store in group_cell_scalar_flux (dealii function in FEValuesBase)
-    fv_->get_function_values(group_global_scalar_flux, group_cell_scalar_flux);
+    std::vector<double> group_cell_scalar_flux =
+        this->GetGroupScalarFlux(group_in);
 
     // Get needed cross-sections:
     auto sigma_s_per_ster = xsec_->sigs_per_ster.at(material_id)(group_in, g);
@@ -171,5 +164,21 @@ SelfAdjointAngularFlux<dim>::CellStreamingMatrix (int q, int dir) {
   
   return return_matrix;
 }
+
+template <int dim>
+std::vector<double>
+SelfAdjointAngularFlux<dim>::GetGroupCellScalarFlux(int group) {
+  std::vector<double> return_vector(n_q_);
+
+  // Get the global scalar flux for the current group
+  auto group_global_scalar_flux =
+      mat_vec_->moments[equ_name_][std::make_tuple(group, 0, 0)];
+  // Evaluate the global scalar flux at the quadrature points of the current
+  // cell and store in return_vector (dealii function in FEValuesBase)
+  fv_->get_function_values(group_global_scalar_flux, return_vector);
+  
+  return return_vector;
+}
+
 
 

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -14,14 +14,14 @@ SelfAdjointAngularFlux<dim>::SelfAdjointAngularFlux(
  * =============================================================================
  */
 
-
 template <int dim>
 void SelfAdjointAngularFlux<dim>::AssembleLinearForms (const int &g) {
-  for (int dir = 0; dir < n_dir_; ++dir) {
-    global_angular_flux_[this->GetCompInd(g, dir)] =
-        *(mat_vec_->sys_flxes[equ_name_][this->GetCompInd(g, dir)]);         
+  if (have_reflective_bc_) {
+    for (int dir = 0; dir < n_dir_; ++dir) {
+      global_angular_flux_[this->GetCompInd(g, dir)] =
+          *(mat_vec_->sys_flxes[equ_name_][this->GetCompInd(g, dir)]);         
+    }
   }
-  
   EquationBase<dim>::AssembleLinearForms(g);
 }
 
@@ -52,6 +52,7 @@ void SelfAdjointAngularFlux<dim>::IntegrateBoundaryBilinearForm (
     }
   }
 }
+
 template<int dim>
 void SelfAdjointAngularFlux<dim>::IntegrateBoundaryLinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
@@ -70,7 +71,6 @@ void SelfAdjointAngularFlux<dim>::IntegrateBoundaryLinearForm (
     double normal_dot_omega = normal_vector * omega_[dir];
 
     if (normal_dot_omega < 0) {
-
       // Retrieve previous iteration angular flux and get local values for the
       // reflected angle
       int reflected_dir = this->ref_dir_ind_[std::make_pair(boundary_id, dir)];

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -1,0 +1,4 @@
+#include "self_adjoint_angular_flux.h"
+
+template <int dim>
+SelfAdjointAngularFlux<dim>::SelfAdjointAngularFlux() {}

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -7,7 +7,118 @@ SelfAdjointAngularFlux<dim>::SelfAdjointAngularFlux(
     std::shared_ptr<FundamentalData<dim>> &data_ptr)
     : EquationBase<dim>(equation_name, prm, data_ptr) {}
 
-// cfem
+/*
+ * =============================================================================
+ * PUBLIC FUNCTIONS
+ * =============================================================================
+ */  
+
+template<int dim>
+void SelfAdjointAngularFlux<dim>::IntegrateScatteringLinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      dealii::Vector<double> &cell_rhs,
+      const int &g,
+      const int &dir) {
+
+  // Get material id for the given cell:
+  int material_id = cell->material_id();
+
+  // SAAF has two scattering terms, the first is proportional to scalar flux
+  // time sigma_s over 4pi, the second has an additional division by sigma_t.
+  // These two vectors hold those values, respectively,  at each quadrature
+  // point:
+  std::vector<double> cell_scatter_flux(n_q_);
+  std::vector<double> cell_scatter_over_total_flux(n_q_);
+  
+  // Iterate over groups to populate cell_scatter_flux
+  for (int group_in = 0; group_in < n_group_; ++group_in) {
+
+    std::vector<double> group_cell_scalar_flux(n_q_);
+    
+    // Get the global scalar flux for the current group
+    auto group_global_scalar_flux =
+        mat_vec_->moments[equ_name_][std::make_tuple(group_in, 0, 0)];
+
+    // Evaluate the global scalar flux at the quadrature points of the current
+    // cell and store in group_cell_scalar_flux (dealii function in FEValuesBase)
+    fv_->get_function_values(group_global_scalar_flux, group_cell_scalar_flux);
+
+    // Get needed cross-sections:
+    auto sigma_s_per_ster = xsec_->sigs_per_ster.at(material_id)(group_in, g);
+    auto inv_sigma_t = xsec_->inv_sigt.at(material_id)[g];
+    
+    // Fold group cell scalar flux into total cell scalar flux and multiply by
+    // appropriate cross-sections:
+    for (int q = 0; q < n_q_; ++q) {
+      cell_scatter_flux[q] += sigma_s_per_ster * group_cell_scalar_flux[q];
+      cell_scatter_over_total_flux[q] = cell_scatter_flux[q] * inv_sigma_t;
+    }
+  }
+
+  // Integrate and add both scattering terms
+  for (int q = 0; q < n_q_; ++q) {
+    cell_scatter_flux[q] *= fv_->JxW(q);
+    for (int i = 0; i < dofs_per_cell_; ++i) {
+      cell_rhs += fv_->shape_value(i, q) * cell_scatter_flux[q];
+      cell_rhs +=
+          omega_[dir] * fv_->shape_grad(i, q) * cell_scatter_over_total_flux[q];
+    }
+  }
+}
 
 template <int dim>
-void SelfAdjointAngularFlux<dim>::PreassembleCellMatrices () {}
+void SelfAdjointAngularFlux<dim>::PreassembleCellMatrices () {
+  // Reinitialize FEM values to an arbitrary cell (the first one) in the list of
+  // local cells.
+  fv_->reinit(dat_ptr_->local_cells[0]);
+
+  // For each quadrature angle, generate the Collision and Streaming matrices
+  for (int q = 0; q < n_q_; ++q) {
+    pre_collision_[q] = this->CellCollisionMatrix(q);
+    // Streaming terms also depend on direction
+    for (int dir = 0; dir < n_dir_; ++dir)
+      pre_streaming_[{dir, q}] = this->CellStreamingMatrix(q, dir);
+  }
+}
+
+/*
+ * =============================================================================
+ * PROTECTED FUNCTIONS
+ * =============================================================================
+ */  
+
+template <int dim>
+dealii::FullMatrix<double>
+SelfAdjointAngularFlux<dim>::CellCollisionMatrix (int q) {
+  
+  dealii::FullMatrix<double> return_matrix (dofs_per_cell_, dofs_per_cell_);
+  
+  for (int i = 0; i < dofs_per_cell_; ++i) {
+      for (int j = 0; j < dofs_per_cell_; ++j) {
+        return_matrix(i,j) =
+            (fv_->shape_value(i,q) * fv_->shape_value(j,q));
+      }
+  }
+  
+  return return_matrix;
+}
+
+template <int dim>
+dealii::FullMatrix<double>
+SelfAdjointAngularFlux<dim>::CellStreamingMatrix (int q, int dir) {
+  
+  dealii::FullMatrix<double> return_matrix (dofs_per_cell_, dofs_per_cell_);
+  
+  for (int i = 0; i < dofs_per_cell_; ++i) {
+      for (int j = 0; j < dofs_per_cell_; ++j) {
+        return_matrix(i,j) =
+            (fv_->shape_grad(i,q) * omega_[dir])
+            *
+            (fv_->shape_grad(j,q) * omega_[dir]);
+      }
+  }
+  
+  return return_matrix;
+}
+
+

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -11,7 +11,16 @@ SelfAdjointAngularFlux<dim>::SelfAdjointAngularFlux(
  * =============================================================================
  * PUBLIC FUNCTIONS
  * =============================================================================
- */  
+ */
+template<int dim>
+void SelfAdjointAngularFlux<dim>::IntegrateBoundaryBilinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      const int &fn,
+      dealii::FullMatrix<double> &cell_matrix,
+      const int &g,
+      const int &dir) {
+}
+
 template<int dim>
 void SelfAdjointAngularFlux<dim>::IntegrateCellBilinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -73,8 +73,7 @@ void SelfAdjointAngularFlux<dim>::IntegrateBoundaryLinearForm (
 
       // Retrieve previous iteration angular flux and get local values for the
       // reflected angle
-      int reflected_dir = dat_ptr_->aq->GetRefDirInd()
-                          [std::make_pair(boundary_id, dir)];
+      int reflected_dir = this->ref_dir_ind_[std::make_pair(boundary_id, dir)];
       
       std::vector<double> angular_flux(n_qf_);
       fvf_->get_function_values(

--- a/src/equation/self_adjoint_angular_flux.cc
+++ b/src/equation/self_adjoint_angular_flux.cc
@@ -1,4 +1,13 @@
 #include "self_adjoint_angular_flux.h"
 
 template <int dim>
-SelfAdjointAngularFlux<dim>::SelfAdjointAngularFlux() {}
+SelfAdjointAngularFlux<dim>::SelfAdjointAngularFlux(
+    const std::string equation_name,
+    const dealii::ParameterHandler &prm,
+    std::shared_ptr<FundamentalData<dim>> &data_ptr)
+    : EquationBase<dim>(equation_name, prm, data_ptr) {}
+
+// cfem
+
+template <int dim>
+void SelfAdjointAngularFlux<dim>::PreassembleCellMatrices () {}

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -26,6 +26,19 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
                          std::shared_ptr<FundamentalData<dim>> &data_ptr);
   ~SelfAdjointAngularFlux() = default;
 
+  /*!
+   * \brief Provides the integrated value of the linear scattering term.
+   */
+  void IntegrateScatteringLinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      dealii::Vector<double> &cell_rhs,
+      const int &g,
+      const int &dir) override;  
+  void PreassembleCellMatrices () override;
+
+  // NOT DONE YET
+  
+  
   void IntegrateCellBilinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
       dealii::FullMatrix<double> &cell_matrix,
@@ -37,7 +50,7 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
       dealii::FullMatrix<double> &cell_matrix,
       const int &g,
       const int &dir) override {};
-  void PreassembleCellMatrices () override;
+
   void IntegrateInterfaceBilinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
       typename dealii::DoFHandler<dim>::cell_iterator &neigh,/*cell iterator for cell*/
@@ -48,11 +61,6 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
       dealii::FullMatrix<double> &ve_ue,
       const int &g,
       const int &i_dir) override {};
-  void IntegrateScatteringLinearForm (
-      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
-      dealii::Vector<double> &cell_rhs,
-      const int &g,
-      const int &dir) override {};  
   void IntegrateBoundaryLinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
       const int &fn,/*face number*/
@@ -65,7 +73,21 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
       const int &g,
       const int &dir) override {};
  protected:
-  std::unordered_map<int, dealii::FullMatrix<double>> &streaming_matrix;
+  using EquationBase<dim>::xsec_;
+  using EquationBase<dim>::pre_streaming_;
+  using EquationBase<dim>::pre_collision_;
+  using EquationBase<dim>::omega_;
+  using EquationBase<dim>::equ_name_;
+  using EquationBase<dim>::fv_;
+  using EquationBase<dim>::dat_ptr_;
+  using EquationBase<dim>::mat_vec_;
+  using EquationBase<dim>::n_group_;
+  using EquationBase<dim>::n_q_;
+  using EquationBase<dim>::n_dir_;
+  using EquationBase<dim>::dofs_per_cell_;
+  
+  dealii::FullMatrix<double> CellCollisionMatrix (int q);
+  dealii::FullMatrix<double> CellStreamingMatrix (int q, int dir);
 };
 
 #endif // BART_SRC_EQUATION_SELF_ADJOINT_ANGULAR_FLUX_H_

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -45,8 +45,7 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
    * \varphi_j(\vec{r}) dV
    * \f]
    *
-   * where \f$\psi\f$ is the angular flux. Adds the result to position
-   * \f$(i,j)\f$ in cell_matrix
+   * where \f$\psi\f$ is the angular flux. 
    *
    * \param cell the cell \f$K\f$.
    * \param cell_matrix the local matrix to be modified, \f$\mathbf{A}\f$

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -1,6 +1,8 @@
 #ifndef BART_SRC_EQUATION_SELF_ADJOINT_ANGULAR_FLUX_H_
 #define BART_SRC_EQUATION_SELF_ADJOINT_ANGULAR_FLUX_H_
 
+#include <algorithm>
+
 #include "equation_base.h"
 
 /*!
@@ -149,18 +151,19 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
       const int &dir) override {};  
 
  protected:
-  using EquationBase<dim>::xsec_;
-  using EquationBase<dim>::pre_streaming_;
-  using EquationBase<dim>::pre_collision_;
-  using EquationBase<dim>::omega_;
+  using EquationBase<dim>::dat_ptr_;
+  using EquationBase<dim>::dofs_per_cell_;
   using EquationBase<dim>::equ_name_;
   using EquationBase<dim>::fv_;
-  using EquationBase<dim>::dat_ptr_;
+  using EquationBase<dim>::is_eigen_problem_;
   using EquationBase<dim>::mat_vec_;
+  using EquationBase<dim>::n_dir_;
   using EquationBase<dim>::n_group_;
   using EquationBase<dim>::n_q_;
-  using EquationBase<dim>::n_dir_;
-  using EquationBase<dim>::dofs_per_cell_;
+  using EquationBase<dim>::omega_;
+  using EquationBase<dim>::pre_streaming_;
+  using EquationBase<dim>::pre_collision_;
+  using EquationBase<dim>::xsec_;
   
   dealii::FullMatrix<double> CellCollisionMatrix (int q);
   dealii::FullMatrix<double> CellStreamingMatrix (int q, int dir);

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -21,7 +21,9 @@ template <int dim>
 class SelfAdjointAngularFlux : public EquationBase<dim> {
  public:
   /*! Class constructor */
-  SelfAdjointAngularFlux();
+  SelfAdjointAngularFlux(const std::string equation_name,
+                         const dealii::ParameterHandler &prm,
+                         std::shared_ptr<FundamentalData<dim>> &data_ptr);
   ~SelfAdjointAngularFlux() = default;
 
   void IntegrateCellBilinearForm (
@@ -35,7 +37,7 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
       dealii::FullMatrix<double> &cell_matrix,
       const int &g,
       const int &dir) override {};
-  void PreassembleCellMatrices () override {};
+  void PreassembleCellMatrices () override;
   void IntegrateInterfaceBilinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
       typename dealii::DoFHandler<dim>::cell_iterator &neigh,/*cell iterator for cell*/
@@ -62,6 +64,8 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
       dealii::Vector<double> &cell_rhs,
       const int &g,
       const int &dir) override {};
+ protected:
+  std::unordered_map<int, dealii::FullMatrix<double>> &streaming_matrix;
 };
 
 #endif // BART_SRC_EQUATION_SELF_ADJOINT_ANGULAR_FLUX_H_

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -15,14 +15,24 @@
  * + \sigma_t\psi = \frac{1}{4\pi}\left[\sigma_s\phi + Q - \vec{\Omega}\cdot
  * \nabla\frac{\sigma_s\phi + Q}{\sigma_t}\right]
  * \f]
+ * Where for eigenvalue problems:
  *
- * With boundary conditions:
+ * \f[
+ * Q = 
+ * \frac{\nu\sigma_f}{4\pi k_{\text{eff}}}\phi
+ * \f]
+ *
+ * 
+ * and with boundary conditions:
  * \f[
  * \psi_b = \cases{
  * F(\vec{r}, \vec{\Omega}) & for $\hat{n} \cdot \vec{\Omega} < 0$ \\
  * \psi(\vec{r}, \vec{\Omega}) & for $\hat{n} \cdot \vec{\Omega} > 0$
  * }
  * \f]
+ *
+ * This class provides a Continuous Galerkin formulation that includes either
+ * vacuum boundary conditions or reflective boundary conditions.
  * 
  * \author Joshua Rehak
  */
@@ -30,11 +40,18 @@
 template <int dim>
 class SelfAdjointAngularFlux : public EquationBase<dim> {
  public:
-  /*! Class constructor */
+  /*! Class constructor.
+   * \param equation_name name of the equation
+   * \param prm ParameterHandler object containing problem definition
+   * \param data_ptr pointer to FundamentalData holding problem data
+   */
   SelfAdjointAngularFlux(const std::string equation_name,
                          const dealii::ParameterHandler &prm,
                          std::shared_ptr<FundamentalData<dim>> &data_ptr);
+
+  /*! Default class destructor */
   ~SelfAdjointAngularFlux() = default;
+  
   /*!
    * \brief Integrates the bilinear boundary terms in the SAAF equation and adds
    *        the values to the matrix cell_matrix.

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -27,7 +27,23 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   ~SelfAdjointAngularFlux() = default;
 
 
-  
+    /*!
+   * \brief Integrates the bilinear terms in the SAAF equation and adds
+   *        the values to the matrix cell_matrix.
+   *           
+   * For a given cell in the triangulation, \f$K \in T_K\f$, with basis functions
+   * \f$\varphi\f$, this function integrates the following two terms using the
+   * quadrature specified in the problem definition:
+   * \f[
+   * A(i,j) = 
+   * \int_{K}\left(\vec{\Omega}\cdot\nabla\varphi_i\right)\frac{1}{\sigma_t}\left(
+   * \vec{\Omega}\cdot\nabla\varphi_j\right) dV +
+   * \int_{K}\sigma_t\varphi_i\varphi_j dV
+   * \f]
+   *
+   * where \f$\psi\f$ is the angular flux. Adds the result to position
+   * \f$(i,j)\f$ in cell_matrix.
+   */
   void IntegrateCellBilinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
       dealii::FullMatrix<double> &cell_matrix,

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -27,9 +27,36 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
                          const dealii::ParameterHandler &prm,
                          std::shared_ptr<FundamentalData<dim>> &data_ptr);
   ~SelfAdjointAngularFlux() = default;
-
-
-    /*!
+  /*!
+   * \brief Integrates the bilinear boundary terms in the SAAF equation and adds
+   *        the values to the matrix cell_matrix.
+   *           
+   * For a given boundary in the triangulation, \f$\partial K \in \partial T_K\f$,
+   * with basis functions \f$\varphi\f$, this function integrates the bilinear
+   * boundary term for one group using the quadrature specified in the
+   * problem definition and adds them to the local cell matrix.
+   * \f[
+   * \mathbf{A}(i,j)_{K,g}' = \mathbf{A}(i,j)_{K,g} +
+   * \int_{\partial K}(\hat{n}\cdot\vec{\Omega})
+   * \varphi_i(\vec{r})\varphi_j(\vec{r})dS
+   * \f]
+   * where \f$\hat{n}\cdot\vec{\Omega} > 0\f$, and adds nothing otherwise.
+   * 
+   * \param cell the cell \f$K\f$.
+   * \param fn face index for the current face in the cell
+   * \param cell_matrix the local matrix to be modified, \f$\mathbf{A}\f$
+   * \param g energy group
+   * \param dir direction \f$\vec{\Omega}\f$.
+   * \return No values returned, modifies input parameter \f$\mathbf{A}\to \mathbf{A}'\f$.   
+   !*/
+  void IntegrateBoundaryBilinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      const int &fn,
+      dealii::FullMatrix<double> &cell_matrix,
+      const int &g,
+      const int &dir) override;
+  
+  /*!
    * \brief Integrates the bilinear terms in the SAAF equation and adds
    *        the values to the matrix cell_matrix.
    *           
@@ -122,15 +149,6 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   void PreassembleCellMatrices () override;
 
   // NOT DONE YET
-  
-  
-
-  void IntegrateBoundaryBilinearForm (
-      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
-      const int &fn,
-      dealii::FullMatrix<double> &cell_matrix,
-      const int &g,
-      const int &dir) override {};
 
   void IntegrateInterfaceBilinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -26,24 +26,41 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
                          std::shared_ptr<FundamentalData<dim>> &data_ptr);
   ~SelfAdjointAngularFlux() = default;
 
-  /*!
-   * \brief Provides the integrated value of the linear scattering term.
-   */
-  void IntegrateScatteringLinearForm (
-      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
-      dealii::Vector<double> &cell_rhs,
-      const int &g,
-      const int &dir) override;  
-  void PreassembleCellMatrices () override;
 
-  // NOT DONE YET
-  
   
   void IntegrateCellBilinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
       dealii::FullMatrix<double> &cell_matrix,
       const int &g,
-      const int &dir) override {};
+      const int &dir) override;
+  
+  /*!
+   * \brief Integrates the linear scattering terms in the SAAF equation and adds
+   *        the values to the vector cell_rhs.
+   *           
+   * For a given cell in the triangulation, \f$K \in T_K\f$, with basis functions
+   * \f$\varphi\f$, this function integrates the following two terms using the
+   * quadrature specified in the problem definition:
+   * \f[
+   * \int_{K}\frac{\sigma_s}{4\pi}\phi\varphi dV + \int_{K}\left(\vec{\Omega}
+   * \cdot \nabla \varphi\right)\frac{\sigma_s}{4\pi\sigma_t}\phi dV
+   * \f]
+   *
+   * where \f$\phi\f$ is the scalar flux. Adds the result per cell DOF to the
+   * input-output vector cell_rhs.
+   */
+  void IntegrateScatteringLinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      dealii::Vector<double> &cell_rhs,
+      const int &g,
+      const int &dir) override;
+  
+  void PreassembleCellMatrices () override;
+
+  // NOT DONE YET
+  
+  
+
   void IntegrateBoundaryBilinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
       const int &fn,
@@ -67,11 +84,7 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
       dealii::Vector<double> &cell_rhs,
       const int &g,
       const int &dir) override {};  
-  void IntegrateCellFixedLinearForm (
-      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
-      dealii::Vector<double> &cell_rhs,
-      const int &g,
-      const int &dir) override {};
+
  protected:
   using EquationBase<dim>::xsec_;
   using EquationBase<dim>::pre_streaming_;

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -214,10 +214,11 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   using EquationBase<dim>::n_dir_;
   using EquationBase<dim>::n_group_;
   using EquationBase<dim>::n_q_;
+  using EquationBase<dim>::n_qf_;
   using EquationBase<dim>::omega_;
   using EquationBase<dim>::pre_streaming_;
   using EquationBase<dim>::pre_collision_;
-  using EquationBase<dim>::scaled_fission_transfer_;
+  using EquationBase<dim>::scaled_fiss_transfer_;
   using EquationBase<dim>::xsec_;
   
   dealii::FullMatrix<double> CellCollisionMatrix (int q);

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -37,32 +37,14 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
    * problem definition and adds them to the local cell matrix. For the case
    * \f$(\vec{n} \cdot \vec{\Omega}) > 0\f$, the boundary condition is
    * \f$\Psi_b(\vec{r},\vec{\Omega}) = \Psi(\vec{r},\vec{\Omega})\f$ and is
-   * partially handled by integrating the following bilinear term (there are also
-   * two linear terms):
+   * partially handled by integrating the following bilinear term (there may
+   * also be a linear term, if there is vacuum or incident boundary conditions):
    * \f[
-   * \mathbf{A}(i,j)_{K,g}' = \mathbf{A}(i,j)_{K,g} -
-   * \int_{\partial K}\frac{1}{\sigma_{t,g}(\vec{r})}
+   * \mathbf{A}(i,j)_{K,g}' = \mathbf{A}(i,j)_{K,g} +
+   * \int_{\partial K}
    * (\hat{n}\cdot\vec{\Omega})\varphi_i(\vec{r})
    * \varphi_j(\vec{r})
    * dS
-   * \f]
-   *
-   * When there are reflective boundary conditions and
-   * \f$(\vec{n} \cdot \vec{\Omega}) < 0\f$, there is an additional bilinear
-   * term:
-   *
-   * \f[
-   * \mathbf{A}(i,j)_{K,g}' = \mathbf{A}(i,j)_{K,g} -
-   * \int_{\partial K}\frac{1}{\sigma_{t,g}(\vec{r})}
-   * (\hat{n}\cdot\vec{\Omega}')\varphi_i(\vec{r})
-   * \varphi_j(\vec{r})
-   * dS
-   * \f]
-   *
-   * where \f$\vec{\Omega}'\f$ is the angle of reflection, given by:
-   *
-   * \f[
-   * \vec{\Omega}' = \vec{\Omega} - 2(\vec{\Omega} \cdot \hat{n})\hat{n}
    * \f]
    * 
    * \param cell the cell \f$K\f$.

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -9,11 +9,19 @@
  * \brief Provides the weak formulation for the Self Adjoint Angular Flux 
  *         (SAAF) equation.
  *
- * This is a second-order formulation of the transport equation, given as:
+ * SAAF is a second-order formulation of the transport equation, given as:
  * \f[
- * -\vec{\Omega} \cdot \nabla \frac{1}{\Sigma_t}\vec{\Omega}\cdot\nabla\psi
- * + \Sigma_t\psi = \frac{1}{4\pi}\left[\Sigma_s\phi + Q - \vec{\Omega}\cdot
- * \nabla\frac{\Sigma_s\phi + Q}{\Sigma_t}\right]
+ * -\vec{\Omega} \cdot \nabla \frac{1}{\sigma_t}\vec{\Omega}\cdot\nabla\psi
+ * + \sigma_t\psi = \frac{1}{4\pi}\left[\sigma_s\phi + Q - \vec{\Omega}\cdot
+ * \nabla\frac{\sigma_s\phi + Q}{\sigma_t}\right]
+ * \f]
+ *
+ * With boundary conditions:
+ * \f[
+ * \psi_b = \cases{
+ * F(\vec{r}, \vec{\Omega}) & for $\hat{n} \cdot \vec{\Omega} < 0$ \\
+ * \psi(\vec{r}, \vec{\Omega}) & for $\hat{n} \cdot \vec{\Omega} > 0$
+ * }
  * \f]
  * 
  * \author Joshua Rehak

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -51,6 +51,8 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
 
   /*! Default class destructor */
   ~SelfAdjointAngularFlux() = default;
+
+  void AssembleLinearForms (const int &g) override;
   
   /*!
    * \brief Integrates the bilinear boundary terms in the SAAF equation and adds
@@ -248,6 +250,8 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   using EquationBase<dim>::scaled_fiss_transfer_;
   using EquationBase<dim>::xsec_;
   void GetGroupCellScalarFlux (std::vector<double> &to_fill, int group);
+  //std::map<int, std::unique_ptr<dealii::Vector<double>>> global_angular_flux_;
+  std::map<int, dealii::Vector<double>> global_angular_flux_;
 };
 
 #endif // BART_SRC_EQUATION_SELF_ADJOINT_ANGULAR_FLUX_H_

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -1,0 +1,67 @@
+#ifndef BART_SRC_EQUATION_SELF_ADJOINT_ANGULAR_FLUX_H_
+#define BART_SRC_EQUATION_SELF_ADJOINT_ANGULAR_FLUX_H_
+
+#include "equation_base.h"
+
+/*!
+ * \brief Provides the weak formulation for the Self Adjoint Angular Flux 
+ *         (SAAF) equation.
+ *
+ * This is a second-order formulation of the transport equation, given as:
+ * \f[
+ * -\vec{\Omega} \cdot \nabla \frac{1}{\Sigma_t}\vec{\Omega}\cdot\nabla\psi
+ * + \Sigma_t\psi = \frac{1}{4\pi}\left[\Sigma_s\phi + Q - \vec{\Omega}\cdot
+ * \nabla\frac{\Sigma_s\phi + Q}{\Sigma_t}\right]
+ * \f]
+ * 
+ * \author Joshua Rehak
+ */
+
+template <int dim>
+class SelfAdjointAngularFlux : public EquationBase<dim> {
+ public:
+  /*! Class constructor */
+  SelfAdjointAngularFlux();
+  ~SelfAdjointAngularFlux() = default;
+
+  void IntegrateCellBilinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      dealii::FullMatrix<double> &cell_matrix,
+      const int &g,
+      const int &dir) override {};
+  void IntegrateBoundaryBilinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      const int &fn,
+      dealii::FullMatrix<double> &cell_matrix,
+      const int &g,
+      const int &dir) override {};
+  void PreassembleCellMatrices () override {};
+  void IntegrateInterfaceBilinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      typename dealii::DoFHandler<dim>::cell_iterator &neigh,/*cell iterator for cell*/
+      const int &fn,/*concerning face number in local cell*/
+      dealii::FullMatrix<double> &vi_ui,
+      dealii::FullMatrix<double> &vi_ue,
+      dealii::FullMatrix<double> &ve_ui,
+      dealii::FullMatrix<double> &ve_ue,
+      const int &g,
+      const int &i_dir) override {};
+  void IntegrateScatteringLinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      dealii::Vector<double> &cell_rhs,
+      const int &g,
+      const int &dir) override {};  
+  void IntegrateBoundaryLinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      const int &fn,/*face number*/
+      dealii::Vector<double> &cell_rhs,
+      const int &g,
+      const int &dir) override {};  
+  void IntegrateCellFixedLinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      dealii::Vector<double> &cell_rhs,
+      const int &g,
+      const int &dir) override {};
+};
+
+#endif // BART_SRC_EQUATION_SELF_ADJOINT_ANGULAR_FLUX_H_

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -167,6 +167,7 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   
   dealii::FullMatrix<double> CellCollisionMatrix (int q);
   dealii::FullMatrix<double> CellStreamingMatrix (int q, int dir);
+  std::vector<double> GetGroupCellScalarFlux(int group);
 };
 
 #endif // BART_SRC_EQUATION_SELF_ADJOINT_ANGULAR_FLUX_H_

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -246,8 +246,6 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   using EquationBase<dim>::scaled_fiss_transfer_;
   using EquationBase<dim>::xsec_;
   
-  dealii::FullMatrix<double> CellCollisionMatrix (int q);
-  dealii::FullMatrix<double> CellStreamingMatrix (int q, int dir);
   std::vector<double> GetGroupCellScalarFlux(int group);
 };
 

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -52,6 +52,15 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   /*! Default class destructor */
   ~SelfAdjointAngularFlux() = default;
 
+  /*!
+   * \brief Assembles the right-hand-side (linear term) of the SAAF equation.
+   *
+   * Override is required because the SAAF RHS requires angular flux information
+   * when reflective boundary conditions are used.
+   *
+   * \param g energy group
+   * 
+   !*/
   void AssembleLinearForms (const int &g) override;
   
   /*!
@@ -218,7 +227,9 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   void PreassembleCellMatrices () override;
 
 
-
+  /*!
+   * \brief There are no interface forms for CFEM.
+   !*/
   void IntegrateInterfaceBilinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &,
       typename dealii::DoFHandler<dim>::cell_iterator &,/*cell iterator for cell*/
@@ -231,27 +242,27 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
       const int &) override {};
 
  protected:
+  void GetGroupCellScalarFlux (std::vector<double> &to_fill, int group);
+  std::map<int, dealii::Vector<double>> global_angular_flux_;
+  
   using EquationBase<dim>::dat_ptr_;
   using EquationBase<dim>::dofs_per_cell_;
   using EquationBase<dim>::equ_name_;
   using EquationBase<dim>::fv_;
   using EquationBase<dim>::fvf_;
   using EquationBase<dim>::have_reflective_bc_;
-  using EquationBase<dim>::is_reflective_bc_;
   using EquationBase<dim>::is_eigen_problem_;
+  using EquationBase<dim>::is_reflective_bc_;
   using EquationBase<dim>::mat_vec_;
   using EquationBase<dim>::n_dir_;
   using EquationBase<dim>::n_group_;
   using EquationBase<dim>::n_q_;
   using EquationBase<dim>::n_qf_;
   using EquationBase<dim>::omega_;
-  using EquationBase<dim>::pre_streaming_;
   using EquationBase<dim>::pre_collision_;
+  using EquationBase<dim>::pre_streaming_;
   using EquationBase<dim>::scaled_fiss_transfer_;
   using EquationBase<dim>::xsec_;
-  void GetGroupCellScalarFlux (std::vector<double> &to_fill, int group);
-  //std::map<int, std::unique_ptr<dealii::Vector<double>>> global_angular_flux_;
-  std::map<int, dealii::Vector<double>> global_angular_flux_;
 };
 
 #endif // BART_SRC_EQUATION_SELF_ADJOINT_ANGULAR_FLUX_H_

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -38,8 +38,8 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
    * \f[
    * \mathbf{A}(i,j)_{K,g}' = \mathbf{A}(i,j)_{K,g} + 
    * \int_{K}\left(\vec{\Omega}\cdot\nabla\varphi_i(\vec{r})\right)
-   * \frac{1}{\sigma_t(\vec{r},g)}\left(\vec{\Omega}\cdot\nabla\varphi_j
-   * (\vec{r})\right) dV + \int_{K}\sigma_t(\vec{r},g)\varphi_i(\vec{r})
+   * \frac{1}{\sigma_{t,g}(\vec{r})}\left(\vec{\Omega}\cdot\nabla\varphi_j
+   * (\vec{r})\right) dV + \int_{K}\sigma_{t,g}(\vec{r})\varphi_i(\vec{r})
    * \varphi_j(\vec{r}) dV
    * \f]
    *
@@ -69,9 +69,16 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
    *
    * \f[
    * \vec{b}(i)_{K,g}' = \vec{b}(i)_{K,g} +
-   * \int_{K}\frac{q(\vec{r})}{4\pi}\varphi_i(\vec{r})dV +
+   * \int_{K}\frac{q_g(\vec{r})}{4\pi}\varphi_i(\vec{r})dV +
    * \int_{K}\left(\vec{\Omega}\cdot\nabla\varphi_i(\vec{r})\right)
-   * \frac{q}{4\pi\sigma_t(\vec{r})}dV
+   * \frac{q_g(\vec{r})}{4\pi\sigma_{t,g}(\vec{r})}dV
+   * \f]
+   *
+   * where \f$q_g(\vec{r})\f$ is a given fixed source or a fission source:
+   *
+   * \f[
+   * q_g(\vec{r}) = \frac{\nu_g \cdot \sigma_{f,g}(\vec{r})_g}
+   * {4\pi k_{\text{eff}}}\phi_g(\vec{r})
    * \f]
    */   
   void IntegrateCellFixedLinearForm (
@@ -89,10 +96,11 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
    * for one group using the quadrature specified in the problem definition and
    * adds them to the cell right-hand side vector.
    * \f[
-   * \vec{b}(i)_{K,g}' = \vec{b}(i)_{K,g} + 
-   * \int_{K}\frac{\sigma_s(\vec{r})}{4\pi}\phi(\vec{r}) \varphi_i(\vec{r}) dV +
+   * \vec{b}(i)_{K,g}' = \vec{b}(i)_{K,g} + \sum_{g'}\left[
+   * \int_{K}\frac{\sigma_{s,g'\to g}(\vec{r})}{4\pi}\phi_{g'}(\vec{r}) \varphi_i(\vec{r}) dV +
    * \int_{K}\left(\vec{\Omega}\cdot \nabla \varphi_i(\vec{r})\right)
-   * \frac{\sigma_s(\vec{r})}{4\pi\sigma_t(\vec{r}) }\phi(\vec{r}) dV
+   * \frac{\sigma_{s,g'\to g}(\vec{r})}{4\pi\sigma_{t,g}(\vec{r}) }\phi_{g'}(\vec{r}) dV
+   * \right]
    * \f]
    *
    * where \f$\phi\f$ is the scalar flux. Adds the result per cell DOFF to the

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -34,13 +34,36 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
    * For a given boundary in the triangulation, \f$\partial K \in \partial T_K\f$,
    * with basis functions \f$\varphi\f$, this function integrates the bilinear
    * boundary term for one group using the quadrature specified in the
-   * problem definition and adds them to the local cell matrix.
+   * problem definition and adds them to the local cell matrix. For the case
+   * \f$(\vec{n} \cdot \vec{\Omega}) > 0\f$, the boundary condition is
+   * \f$\Psi_b(\vec{r},\vec{\Omega}) = \Psi(\vec{r},\vec{\Omega})\f$ and is
+   * partially handled by integrating the following bilinear term (there are also
+   * two linear terms):
    * \f[
-   * \mathbf{A}(i,j)_{K,g}' = \mathbf{A}(i,j)_{K,g} +
-   * \int_{\partial K}(\hat{n}\cdot\vec{\Omega})
-   * \varphi_i(\vec{r})\varphi_j(\vec{r})dS
+   * \mathbf{A}(i,j)_{K,g}' = \mathbf{A}(i,j)_{K,g} -
+   * \int_{\partial K}\frac{1}{\sigma_{t,g}(\vec{r})}
+   * (\hat{n}\cdot\vec{\Omega})\varphi_i(\vec{r})
+   * \varphi_j(\vec{r})
+   * dS
    * \f]
-   * where \f$\hat{n}\cdot\vec{\Omega} > 0\f$, and adds nothing otherwise.
+   *
+   * When there are reflective boundary conditions and
+   * \f$(\vec{n} \cdot \vec{\Omega}) < 0\f$, there is an additional bilinear
+   * term:
+   *
+   * \f[
+   * \mathbf{A}(i,j)_{K,g}' = \mathbf{A}(i,j)_{K,g} -
+   * \int_{\partial K}\frac{1}{\sigma_{t,g}(\vec{r})}
+   * (\hat{n}\cdot\vec{\Omega}')\varphi_i(\vec{r})
+   * \varphi_j(\vec{r})
+   * dS
+   * \f]
+   *
+   * where \f$\vec{\Omega}'\f$ is the angle of reflection, given by:
+   *
+   * \f[
+   * \vec{\Omega}' = \vec{\Omega} - 2(\vec{\Omega} \cdot \hat{n})\hat{n}
+   * \f]
    * 
    * \param cell the cell \f$K\f$.
    * \param fn face index for the current face in the cell
@@ -172,6 +195,7 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   using EquationBase<dim>::dofs_per_cell_;
   using EquationBase<dim>::equ_name_;
   using EquationBase<dim>::fv_;
+  using EquationBase<dim>::fvf_;
   using EquationBase<dim>::is_eigen_problem_;
   using EquationBase<dim>::mat_vec_;
   using EquationBase<dim>::n_dir_;

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -80,10 +80,10 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
    * \return No values returned, modifies input parameter \f$\mathbf{A}\to \mathbf{A}'\f$.   
    !*/
   void IntegrateBoundaryBilinearForm (
-      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
-      const int &fn,
+      typename dealii::DoFHandler<dim>::active_cell_iterator &,
+      const int &,
       dealii::FullMatrix<double> &cell_matrix,
-      const int &g,
+      const int &,
       const int &dir) override;
   /*!
    * \brief Integrates the linear bilinear boundary term in the SAAF equation and adds
@@ -215,18 +215,18 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   
   void PreassembleCellMatrices () override;
 
-  // NOT DONE YET
+
 
   void IntegrateInterfaceBilinearForm (
-      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
-      typename dealii::DoFHandler<dim>::cell_iterator &neigh,/*cell iterator for cell*/
-      const int &fn,/*concerning face number in local cell*/
-      dealii::FullMatrix<double> &vi_ui,
-      dealii::FullMatrix<double> &vi_ue,
-      dealii::FullMatrix<double> &ve_ui,
-      dealii::FullMatrix<double> &ve_ue,
-      const int &g,
-      const int &i_dir) override {};
+      typename dealii::DoFHandler<dim>::active_cell_iterator &,
+      typename dealii::DoFHandler<dim>::cell_iterator &,/*cell iterator for cell*/
+      const int &,/*concerning face number in local cell*/
+      dealii::FullMatrix<double> &,
+      dealii::FullMatrix<double> &,
+      dealii::FullMatrix<double> &,
+      dealii::FullMatrix<double> &,
+      const int &,
+      const int &) override {};
 
  protected:
   using EquationBase<dim>::dat_ptr_;
@@ -234,6 +234,8 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   using EquationBase<dim>::equ_name_;
   using EquationBase<dim>::fv_;
   using EquationBase<dim>::fvf_;
+  using EquationBase<dim>::have_reflective_bc_;
+  using EquationBase<dim>::is_reflective_bc_;
   using EquationBase<dim>::is_eigen_problem_;
   using EquationBase<dim>::mat_vec_;
   using EquationBase<dim>::n_dir_;
@@ -245,8 +247,7 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   using EquationBase<dim>::pre_collision_;
   using EquationBase<dim>::scaled_fiss_transfer_;
   using EquationBase<dim>::xsec_;
-  
-  std::vector<double> GetGroupCellScalarFlux(int group);
+  void GetGroupCellScalarFlux (std::vector<double> &to_fill, int group);
 };
 
 #endif // BART_SRC_EQUATION_SELF_ADJOINT_ANGULAR_FLUX_H_

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -38,7 +38,7 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
    * \f$(\vec{n} \cdot \vec{\Omega}) > 0\f$, the boundary condition is
    * \f$\Psi_b(\vec{r},\vec{\Omega}) = \Psi(\vec{r},\vec{\Omega})\f$ and is
    * partially handled by integrating the following bilinear term (there may
-   * also be a linear term, if there is vacuum or incident boundary conditions):
+   * also be a linear term):
    * \f[
    * \mathbf{A}(i,j)_{K,g}' = \mathbf{A}(i,j)_{K,g} +
    * \int_{\partial K}

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -60,6 +60,43 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
       dealii::FullMatrix<double> &cell_matrix,
       const int &g,
       const int &dir) override;
+  /*!
+   * \brief Integrates the linear bilinear boundary term in the SAAF equation and adds
+   *        the values to the matrix cell_matrix.
+   *           
+   * For a given boundary in the triangulation, \f$\partial K \in \partial T_K\f$,
+   * with basis functions \f$\varphi\f$, this function integrates the linear
+   * boundary term for one group using the quadrature specified in the
+   * problem definition and adds them to the local cell right-hand side. For the case
+   * \f$(\vec{n} \cdot \vec{\Omega}) < 0\f$, the boundary condition is
+   * \f$\Psi_b(\vec{r},\vec{\Omega}) = \Psi_{\text{inc}}(\vec{r},\vec{\Omega})\f$ and is
+   * partially handled by integrating the following bilinear term (there is also
+   * a bilinear term):
+   * \f[
+   * \vec{b}(i)_{K,g}' = \vec{b}(i)_{K,g} +
+   * \int_{\partial K}
+   * (\hat{n}\cdot\vec{\Omega})\varphi_i(\vec{r})
+   * \Psi_{\text{inc},g}(\vec{r})
+   * dS
+   * \f]
+   *
+   * For vacuum boundary conditions, \f$\Psi_{\text{inc},g} = 0\f$. For reflective
+   * boundary conditions, it is equal to the angular flux on the boundary in
+   * the previous iteration.
+   * 
+   * \param cell the cell \f$K\f$.
+   * \param fn face index for the current face in the cell
+   * \param cell_rhs the local cell right-hand side to be modified, \f$\vec{b}\f$
+   * \param g energy group
+   * \param dir direction \f$\vec{\Omega}\f$.
+   * \return No values returned, modifies input parameter \f$\vec{b}\to \vec{b}'\f$.   
+   !*/
+  void IntegrateBoundaryLinearForm (
+      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
+      const int &fn,/*face number*/
+      dealii::Vector<double> &cell_rhs,
+      const int &g,
+      const int &dir) override;  
   
   /*!
    * \brief Integrates the bilinear terms in the SAAF equation and adds
@@ -165,12 +202,6 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
       dealii::FullMatrix<double> &ve_ue,
       const int &g,
       const int &i_dir) override {};
-  void IntegrateBoundaryLinearForm (
-      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
-      const int &fn,/*face number*/
-      dealii::Vector<double> &cell_rhs,
-      const int &g,
-      const int &dir) override {};  
 
  protected:
   using EquationBase<dim>::dat_ptr_;

--- a/src/equation/self_adjoint_angular_flux.h
+++ b/src/equation/self_adjoint_angular_flux.h
@@ -163,6 +163,7 @@ class SelfAdjointAngularFlux : public EquationBase<dim> {
   using EquationBase<dim>::omega_;
   using EquationBase<dim>::pre_streaming_;
   using EquationBase<dim>::pre_collision_;
+  using EquationBase<dim>::scaled_fission_transfer_;
   using EquationBase<dim>::xsec_;
   
   dealii::FullMatrix<double> CellCollisionMatrix (int q);

--- a/src/equation/tests/self_adjoint_angular_flux_integration_test.cc
+++ b/src/equation/tests/self_adjoint_angular_flux_integration_test.cc
@@ -24,8 +24,3 @@ void SAAFIntegrationTest::SetUp() {
   const char *parse_string = parameter_oss.str().c_str();
   prm_.parse_input_from_string(parse_string);
 }
-
-TEST_F(SAAFIntegrationTest, Dummy){
-  EXPECT_TRUE(true);
-}
-

--- a/src/equation/tests/self_adjoint_angular_flux_integration_test.cc
+++ b/src/equation/tests/self_adjoint_angular_flux_integration_test.cc
@@ -1,0 +1,31 @@
+#include "../self_adjoint_angular_flux.h"
+
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+#include "../../test_helpers/gmock_wrapper.h"
+#include "../../common/problem_definition.h"
+
+class SAAFIntegrationTest : public ::testing::Test {
+ protected:
+  void SetUp() override;
+  dealii::ParameterHandler prm_;
+};
+
+void SAAFIntegrationTest::SetUp() {
+  bparams::DeclareParameters(prm_);
+  std::ostringstream parameter_oss;
+  parameter_oss << "set transport model          = saaf\n"
+                << "set angular quadrature name  = lsgc\n"
+                << "set angular quadrature order = 2\n"
+                << "set ho linear solver name    = direct\n"
+                << "set ho preconditioner name   = bssor\n";
+  const char *parse_string = parameter_oss.str().c_str();
+  prm_.parse_input_from_string(parse_string);
+}
+
+TEST_F(SAAFIntegrationTest, Dummy){
+  EXPECT_TRUE(true);
+}
+


### PR DESCRIPTION
Adds a continuous finite element formulation of the self-adjoint angular flux form of the multigroup transport equation with vacuum and reflective boundary conditions.

Tests:
2 regression tests, one with vacuum BCs and one with reflective BCs. Both use the protocol buffer file format for materials.