### PR TITLE
Code Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
 script:
  - docker exec bart cmake .
  - docker exec bart make
- - docker exec bart bash -c "./xtrans_test --gtest_filter=-*MPI*"
- - docker exec bart bash -c "mpirun -np 1 --allow-run-as-root ./xtrans_test --gtest_filter=*MPI*"
+ - docker exec bart bash -c "./bart_test"
+ - docker exec bart bash -c "mpirun -np 1 --allow-run-as-root ./bart_test --mpi"
 
 after_success:
  - docker exec bart bash -c "./coverage.sh"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
-PROJECT(xtrans)
+PROJECT(bart)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 ### DEPENDENCIES #####################################################
@@ -89,16 +89,16 @@ include_directories(${GTEST_INCLUDE_DIRS}
   ${CMAKE_SOURCE_DIR}/inc
   ${PROTO_INC_DIR})
 
-# Add xtrans executables
-ADD_EXECUTABLE(xtrans ${sources})
-ADD_EXECUTABLE(xtrans_test ${testing_sources})
+# Add BART executables
+ADD_EXECUTABLE(bart ${sources})
+ADD_EXECUTABLE(bart_test ${testing_sources})
 
-# Add testing definition and library to xtrans_test
-target_compile_definitions(xtrans_test PUBLIC -DTEST)
+# Add testing definition and library to bart_test
+target_compile_definitions(bart_test PUBLIC -DTEST)
 
 
-target_link_libraries(xtrans ${Protobuf_LIBRARIES})
-target_link_libraries(xtrans_test ${GTEST_BOTH_LIBRARIES}
+target_link_libraries(bart ${Protobuf_LIBRARIES})
+target_link_libraries(bart_test ${GTEST_BOTH_LIBRARIES}
   ${GMOCK_BOTH_LIBRARIES} ${Protobuf_LIBRARIES})
 
 # Add subdirectory builds to build libraries for CTEST
@@ -107,8 +107,8 @@ ADD_SUBDIRECTORY(${CMAKE_SOURCE_DIR}/src/mesh)
 # Add unit testing subdirectories
 ADD_SUBDIRECTORY(${CMAKE_SOURCE_DIR}/tests/mesh)
 
-DEAL_II_SETUP_TARGET(xtrans)
-DEAL_II_SETUP_TARGET(xtrans_test)
+DEAL_II_SETUP_TARGET(bart)
+DEAL_II_SETUP_TARGET(bart_test)
 
 ### TEST FILES ##################################################
 # Create copies of .gold files in the BART/src directory for gtest
@@ -126,7 +126,7 @@ foreach(test_file ${gtest_files})
     COMMAND ${CMAKE_COMMAND} -E copy ${test_file}
             ${CMAKE_CURRENT_BINARY_DIR}/test_data/${file_name})
 endforeach()
-add_dependencies(xtrans_test copy_gtest_gold_files)
+add_dependencies(bart_test copy_gtest_gold_files)
 
 # Creates copies of .output files in the BART/test directory for CTEST
 
@@ -140,9 +140,9 @@ foreach(test_file ${ctest_files})
     TARGET copy_ctest_output_files PRE_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${test_file} ${file_name})
 endforeach()
-add_dependencies(xtrans_test copy_ctest_output_files)
+add_dependencies(bart_test copy_ctest_output_files)
 
 # Create copies of material protocol buffer data
 add_custom_target(copy_protoc_files ALL)
 file(COPY "./src/material/tests/data/" DESTINATION "./test_data/material")
-add_dependencies(xtrans_test copy_protoc_files)
+add_dependencies(bart_test copy_protoc_files)

--- a/src/aqdata/lsgc.cc
+++ b/src/aqdata/lsgc.cc
@@ -58,9 +58,9 @@ void LSGC<dim>::ProduceAQ () {
     }
   }
 
-  AssertThrow (this->n_dir_==this->wi_.size(),
+  AssertThrow (this->n_dir_==static_cast<int>(this->wi_.size()),
                dealii::ExcMessage("calculated number of angles should be the same as number of angular weights"));
-  AssertThrow (this->n_dir_==this->omega_i_.size(),
+  AssertThrow (this->n_dir_==static_cast<int>(this->omega_i_.size()),
                dealii::ExcMessage("calculated number of angles should be the same as number of angles"));
 
   this->n_total_ho_vars_ = this->n_dir_ * this->n_group_;

--- a/src/aqdata/tests/lsgc_test.cc
+++ b/src/aqdata/tests/lsgc_test.cc
@@ -40,7 +40,7 @@ void LSGCTest::AQDataTest() {
   lsgc_ptr->MakeAQ();
   auto wi = lsgc_ptr->GetAQWeights();
   auto omega_i = lsgc_ptr->GetAQDirs();
-  for (int i=0; i<wi.size(); ++i)
+  for (unsigned int i=0; i<wi.size(); ++i)
   {
     dealii::deallog << "Weight: " << wi[i] << "; Omega: ";
     for (int j=0; j<dim; ++j)

--- a/src/common/bart_builder.h
+++ b/src/common/bart_builder.h
@@ -97,6 +97,6 @@ namespace bbuilders {
   template <int dim>
   std::unique_ptr<IGBase<dim>> BuildIGItr (const dealii::ParameterHandler &prm,
       std::shared_ptr<FundamentalData<dim>> &dat_ptr);
-};
+}
 
 #endif // BART_SRC_COMMON_BART_BUILDER_H_

--- a/src/common/bart_driver.cc
+++ b/src/common/bart_driver.cc
@@ -72,7 +72,39 @@ BARTDriver<3>::BARTDriver (dealii::ParameterHandler &prm)
     equ_ptrs_(bbuilders::BuildEqu(prm, dat_ptr_)) {}
 
 template <int dim>
-BARTDriver<dim>::~BARTDriver () {}
+BARTDriver<dim>::~BARTDriver () {
+  // free matrices
+  for (auto & mats : dat_ptr_->mat_vec->sys_mats) {
+    // mats.first==equ name, mats.second==matrix pointers
+    for (auto & matrix : mats.second) {
+      // delete dynamically allocated memory
+      delete matrix;
+      // set dangling pointers to null
+      matrix = nullptr;
+    }
+  }
+
+  for (auto & fluxes : dat_ptr_->mat_vec->sys_flxes) {
+    for (auto & flux : fluxes.second) {
+      delete flux;
+      flux = nullptr;
+    }
+  }
+
+  for (auto & rhses : dat_ptr_->mat_vec->sys_rhses) {
+    for (auto & rhs : rhses.second) {
+      delete rhs;
+      rhs = nullptr;
+    }
+  }
+
+  for (auto & fixed_rhses : dat_ptr_->mat_vec->sys_fixed_rhses) {
+    for (auto & fixed_rhs : fixed_rhses.second) {
+      delete fixed_rhs;
+      fixed_rhs = nullptr;
+    }
+  }
+}
 
 template <>
 void BARTDriver<1>::MakeGrid() {
@@ -294,7 +326,7 @@ void BARTDriver<2>::OutputResults () const {
     std::ostringstream os;
     os << output_fname_ << ".pvtu";
     std::ofstream master_output ((os.str()).c_str ());
-    
+
     data_out.write_pvtu_record (master_output, filenames);
   }
 }

--- a/src/common/bart_driver.cc
+++ b/src/common/bart_driver.cc
@@ -253,16 +253,16 @@ void BARTDriver<1>::OutputResults () const {
     }
   }
   dealii::Vector<float> subdomain (tria.n_active_cells ());
-  for (int i=0; i<subdomain.size(); ++i)
-    subdomain(i) = 0;
+  for (auto &it : subdomain)
+    it = 0;
   data_out.add_data_vector (subdomain, "subdomain");
 
   if (is_eigen_problem_) {
     // add keff to the output file
     dealii::Vector<float> keffs (tria.n_active_cells ());
     const double keff = iter_cls_.GetKeff();
-    for (int i=0; i<keffs.size(); ++i)
-      keffs(i) = keff;
+    for (auto& it : keffs)
+      it = keff;
     data_out.add_data_vector (keffs, "keff");
   }
 
@@ -297,8 +297,8 @@ void BARTDriver<2>::OutputResults () const {
   }
   dealii::Vector<float> subdomain (distributed_tria.n_active_cells());
   const int proc_id = distributed_tria.locally_owned_subdomain ();
-  for (int i=0; i<subdomain.size(); ++i)
-    subdomain(i) = proc_id;
+  for (auto &it : subdomain)
+    it = proc_id;
   data_out.add_data_vector (subdomain, "subdomain");
 
   //if (is_eigen_problem_)
@@ -306,8 +306,8 @@ void BARTDriver<2>::OutputResults () const {
     // add keff to the output file
     dealii::Vector<float> keffs (distributed_tria.n_active_cells());
     double keff = is_eigen_problem_?iter_cls_.GetKeff():0.0;
-    for (int i=0; i<keffs.size(); ++i)
-      keffs(i) = keff;
+    for (auto& it : keffs)
+      it = keff;
     data_out.add_data_vector (keffs, "keff");
   //}
   data_out.build_patches ();
@@ -346,14 +346,14 @@ void BARTDriver<3>::OutputResults () const {
   }
   dealii::Vector<float> subdomain (distributed_tria.n_active_cells());
   const int proc_id = distributed_tria.locally_owned_subdomain ();
-  for (int i=0; i<subdomain.size(); ++i)
-    subdomain(i) = proc_id;
+  for (auto& it : subdomain)
+    it = proc_id;
   data_out.add_data_vector (subdomain, "subdomain");
 
   dealii::Vector<float> keffs (distributed_tria.n_active_cells());
   double keff = is_eigen_problem_ ? iter_cls_.GetKeff() : 0.0;
-  for (int i=0; i<keffs.size(); ++i)
-  keffs(i) = keff;
+  for (auto& it : keffs)
+    it = keff;
   data_out.add_data_vector (keffs, "keff");
 
   data_out.build_patches ();

--- a/src/common/bart_driver.cc
+++ b/src/common/bart_driver.cc
@@ -78,30 +78,30 @@ BARTDriver<dim>::~BARTDriver () {
     // mats.first==equ name, mats.second==matrix pointers
     for (auto & matrix : mats.second) {
       // delete dynamically allocated memory
-      delete matrix;
+      delete matrix.second;
       // set dangling pointers to null
-      matrix = nullptr;
+      matrix.second = nullptr;
     }
   }
 
   for (auto & fluxes : dat_ptr_->mat_vec->sys_flxes) {
     for (auto & flux : fluxes.second) {
-      delete flux;
-      flux = nullptr;
+      delete flux.second;
+      flux.second = nullptr;
     }
   }
 
   for (auto & rhses : dat_ptr_->mat_vec->sys_rhses) {
     for (auto & rhs : rhses.second) {
-      delete rhs;
-      rhs = nullptr;
+      delete rhs.second;
+      rhs.second = nullptr;
     }
   }
 
   for (auto & fixed_rhses : dat_ptr_->mat_vec->sys_fixed_rhses) {
     for (auto & fixed_rhs : fixed_rhses.second) {
-      delete fixed_rhs;
-      fixed_rhs = nullptr;
+      delete fixed_rhs.second;
+      fixed_rhs.second = nullptr;
     }
   }
 }

--- a/src/common/tests/bart_builder_test.cc
+++ b/src/common/tests/bart_builder_test.cc
@@ -119,7 +119,7 @@ void BARTBuilderTest::AQBuilderTest () {
   // check output
   std::string filename = "aq_builder_"+dealii::Utilities::int_to_string(dim)+"d";
   btest::GoldTestInit(filename);
-  for (int i=0; i<wi.size(); ++i) {
+  for (unsigned int i=0; i<wi.size(); ++i) {
     dealii::deallog << "Weight: " << wi[i] << "; Omega: ";
     for (int j=0; j<dim; ++j)
       dealii::deallog << omega_i[i][j] << " ";

--- a/src/equation/even_parity.cc
+++ b/src/equation/even_parity.cc
@@ -104,11 +104,11 @@ void EvenParity<dim>::IntegrateBoundaryBilinearForm (
 
 template <int dim>
 void EvenParity<dim>::IntegrateBoundaryLinearForm (
-    typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
-    const int &fn,/*face number*/
-    dealii::Vector<double> &cell_rhs,
-    const int &g,
-    const int &dir) {
+    typename dealii::DoFHandler<dim>::active_cell_iterator &,
+    const int &,/*face number*/
+    dealii::Vector<double> &,
+    const int &,
+    const int &) {
   // We implement nothing for even parity boundary linear form. In reflective BC,
   // even parity realizes it via modifying bilinear form. Also, we assume vacuum
   // BC so nothing needs to be realized therein.
@@ -118,7 +118,7 @@ template <int dim>
 void EvenParity<dim>::IntegrateInterfaceBilinearForm (
     typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
     typename dealii::DoFHandler<dim>::cell_iterator &neigh,/*cell iterator for cell*/
-    const int &fn,/*concerning face number in local cell*/
+    const int &,/*concerning face number in local cell*/
     dealii::FullMatrix<double> &vp_up,
     dealii::FullMatrix<double> &vp_un,
     dealii::FullMatrix<double> &vn_up,
@@ -214,7 +214,7 @@ void EvenParity<dim>::IntegrateScatteringLinearForm (
     typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
     dealii::Vector<double> &cell_rhs,
     const int &g,
-    const int &dir) {
+    const int &) {
   // dir info is irrelavant for even parity
   // TODO: Anisotropic scattering is not included
   int mid = cell->material_id ();
@@ -240,7 +240,7 @@ void EvenParity<dim>::IntegrateCellFixedLinearForm (
     typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
     dealii::Vector<double> &cell_rhs,
     const int &g,
-    const int &dir) {
+    const int &) {
   // dir info is irrelavant for even parity
   int mid = cell->material_id ();
   std::vector<double> q_at_qp (this->n_q_);

--- a/src/equation/even_parity.h
+++ b/src/equation/even_parity.h
@@ -122,7 +122,7 @@ public:
   void IntegrateInterfaceBilinearForm (
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
       typename dealii::DoFHandler<dim>::cell_iterator &neigh,/*cell iterator for cell*/
-      const int &fn,/*concerning face number in local cell*/
+      const int &,/*concerning face number in local cell*/
       dealii::FullMatrix<double> &vp_up,
       dealii::FullMatrix<double> &vp_un,
       dealii::FullMatrix<double> &vn_up,
@@ -145,7 +145,7 @@ public:
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
       dealii::Vector<double> &cell_rhs,
       const int &g,
-      const int &dir);
+      const int &);
 
   /*!
    This function provides cellwise integrator for linear form assembly specifically
@@ -166,7 +166,7 @@ public:
       typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
       dealii::Vector<double> &cell_rhs,
       const int &g,
-      const int &dir);
+      const int &);
 
   /*!
    Function to override for boundary linear form from EquationBase. It essentially
@@ -181,11 +181,11 @@ public:
    \return Void.
    */
   void IntegrateBoundaryLinearForm (
-      typename dealii::DoFHandler<dim>::active_cell_iterator &cell,
-      const int &fn,/*face number*/
-      dealii::Vector<double> &cell_rhs,
-      const int &g,
-      const int &dir);
+      typename dealii::DoFHandler<dim>::active_cell_iterator &,
+      const int &,/*face number*/
+      dealii::Vector<double> &,
+      const int &,
+      const int &);
 
 private:
   //! Polynomial order related part of penalty coefficient.

--- a/src/equation/linear_algebra.cc
+++ b/src/equation/linear_algebra.cc
@@ -25,7 +25,7 @@ LinearAlgebra::~LinearAlgebra () {}
 void LinearAlgebra::InitPrecond (
     std::unordered_map<int, dealii::PETScWrappers::MPI::SparseMatrix*> &sys_mats,
     std::unordered_map<int, dealii::PETScWrappers::MPI::Vector*> &sys_rhses) {
-  AssertThrow (n_total_vars_==sys_mats.size(),
+  AssertThrow (n_total_vars_ == static_cast<int>(sys_mats.size()),
       dealii::ExcMessage("num of system matrices should be equal to total variable number"));
   if (linear_solver_name_!="direct") {
     if (preconditioner_name_=="amg") {
@@ -93,7 +93,7 @@ void LinearAlgebra::LinAlgSolve (
     std::unordered_map<int, dealii::PETScWrappers::MPI::SparseMatrix*> &sys_mats,
     std::unordered_map<int, dealii::PETScWrappers::MPI::Vector*> &sys_flxes,
     std::unordered_map<int, dealii::PETScWrappers::MPI::Vector*> &sys_rhses,
-    std::unordered_map<int, dealii::ConstraintMatrix*> &constraints,
+    std::unordered_map<int, dealii::ConstraintMatrix*> &,
     const int &i) {
   if (linear_solver_name_=="cg") {
     dealii::PETScWrappers::SolverCG solver (*cn_, MPI_COMM_WORLD);

--- a/src/equation/linear_algebra.h
+++ b/src/equation/linear_algebra.h
@@ -84,15 +84,16 @@ class LinearAlgebra {
           dealii::PETScWrappers::MPI::SparseMatrix*> &sys_mats,
       std::unordered_map<int, dealii::PETScWrappers::MPI::Vector*> &sys_flxes,
       std::unordered_map<int, dealii::PETScWrappers::MPI::Vector*> &sys_rhses,
-      std::unordered_map<int, dealii::ConstraintMatrix*> &constraints,
+      std::unordered_map<int, dealii::ConstraintMatrix*> &,
       const int &i);
 
 private:
+
+  const std::string equ_name_;//!< Name of the target equation.
+  
   const int n_total_vars_;//!< Total number of variables in the target system.
 
   const bool have_reflective_bc_;//!< Boolean to determine if there's any reflective boundary
-
-  const std::string equ_name_;//!< Name of the target equation.
 
   double ssor_omega_;//!< The relaxation factor if block SSOR is used as preconditioner.
 

--- a/src/iteration/eigen_base.cc
+++ b/src/iteration/eigen_base.cc
@@ -29,11 +29,6 @@ void EigenBase<dim>::DoIterations (std::unordered_map<std::string,
   }
 }
 
-// Override this function to do specific eigenvalue iteration as desired
-template <int dim>
-void EigenBase<dim>::EigenIterations (
-    std::unique_ptr<EquationBase<dim>> &equ_ptr) {}
-
 template <int dim>
 void EigenBase<dim>::UpdatePrevSflxesFissSrcKeff (const std::string &equ_name) {
   // update scalar fluxes from previous eigen iteration

--- a/src/iteration/eigen_base.h
+++ b/src/iteration/eigen_base.h
@@ -34,8 +34,8 @@ class EigenBase : public IterationBase<dim> {
 
    \return Void.
    */
-  virtual void EigenIterations (
-      std::unique_ptr<EquationBase<dim>> &equ_ptrs) = 0;
+  virtual void EigenIterations
+  (std::unique_ptr<EquationBase<dim>> &equ_ptrs) = 0;
 
   /*!
    Function to update \f$\phi\f$, fission source and \f$k_\mathrm{eff}\f$ from

--- a/src/iteration/iteration_base.cc
+++ b/src/iteration/iteration_base.cc
@@ -4,12 +4,13 @@ template <int dim>
 IterationBase<dim>::IterationBase (const dealii::ParameterHandler &prm,
     std::shared_ptr<FundamentalData<dim>> &dat_ptr)
     :
-    dat_ptr_(dat_ptr),
-    mat_vec_(dat_ptr->mat_vec),
     n_group_(prm.get_integer("number of groups")),
     is_eigen_problem_(prm.get_bool("do eigenvalue calculations")),
     do_nda_(prm.get_bool("do nda")),
-    ho_equ_name_(prm.get("transport model")) {}
+    ho_equ_name_(prm.get("transport model")),
+    dat_ptr_(dat_ptr),
+    mat_vec_(dat_ptr->mat_vec)
+{}
 
 template <int dim>
 IterationBase<dim>::~IterationBase () {}
@@ -26,7 +27,7 @@ double IterationBase<dim>::EstimatePhiDiff (
   AssertThrow (phis1.size ()== phis2.size (),
                dealii::ExcMessage ("n_groups for different phis should be identical"));
   double err = 0.0;
-  for (int i=0; i<phis1.size (); ++i)
+  for (unsigned int i=0; i<phis1.size (); ++i)
     err = std::max (err, EstimatePhiDiff(phis1[i],phis2[i]));
   return err;
 }
@@ -59,7 +60,7 @@ double IterationBase<dim>::EstimatePhiDiff (
   AssertThrow (phis1.size()==phis2.size(),
       dealii::ExcMessage("lengths of both vectors of solutions should be the same"));
   double err = 0.0;
-  for (int g=0; g<phis1.size(); ++g)
+  for (unsigned int g=0; g<phis1.size(); ++g)
     err = std::max(err, EstimatePhiDiff(phis1[std::make_tuple(g,0,0)],
         phis2[std::make_tuple(g,0,0)]));
   return err;

--- a/src/iteration/mg_base.cc
+++ b/src/iteration/mg_base.cc
@@ -46,11 +46,11 @@ void MGBase<dim>::MGIterations (std::unique_ptr<EquationBase<dim>> &equ_ptr) {
 }
 
 template <int dim>
-void MGBase<dim>::NonthermalSolves (std::unique_ptr<EquationBase<dim>> &equ_ptr)
+void MGBase<dim>::NonthermalSolves (std::unique_ptr<EquationBase<dim>> &)
 {}
 
 template <int dim>
-void MGBase<dim>::ThermalIterations (std::unique_ptr<EquationBase<dim>> &equ_ptr)
+void MGBase<dim>::ThermalIterations (std::unique_ptr<EquationBase<dim>> &)
 {}
 
 template class MGBase<1>;

--- a/src/iteration/mg_base.h
+++ b/src/iteration/mg_base.h
@@ -71,7 +71,7 @@ class MGBase : public IterationBase<dim> {
    \param equ_ptr Pointer of EquationBase object.
    \return Void.
    */
-  virtual void NonthermalSolves(std::unique_ptr<EquationBase<dim>> &equ_ptr);
+  virtual void NonthermalSolves(std::unique_ptr<EquationBase<dim>> &);
 
   /*!
    This virtual function performs iterative energy solves over thermal groups.
@@ -83,7 +83,7 @@ class MGBase : public IterationBase<dim> {
    \param equ_ptrs A vector of shared_ptr's of EquationBase objects.
    \return Void.
    */
-  virtual void ThermalIterations (std::unique_ptr<EquationBase<dim>> &equ_ptr);
+  virtual void ThermalIterations (std::unique_ptr<EquationBase<dim>> &);
 
  protected:
   int g_thermal_;//!< Starting group index where upscattering exists.

--- a/src/iteration/source_iteration.cc
+++ b/src/iteration/source_iteration.cc
@@ -14,7 +14,7 @@ void SourceIteration<dim>::IGIterations (
     std::unique_ptr<EquationBase<dim>> &equ_ptr,
     const int &g) {
   double err = 1.0;
-  int iter = 0;
+  //int iter = 0;
   const std::string equ_name = equ_ptr->GetEquName();
   while (err>this->err_phi_tol_) {
     // generate rhs for group g

--- a/src/mesh/mesh_generator.cc
+++ b/src/mesh/mesh_generator.cc
@@ -138,7 +138,7 @@ void MeshGenerator<dim>::NonFuelPin2DGrid (dealii::Triangulation<2> &tria,
 
 template <>
 void MeshGenerator<1>::GenerateInitialUnstructGrid (
-    dealii::Triangulation<1> &tria) {}
+    dealii::Triangulation<1> &) {}
 
 template <>
 void MeshGenerator<2>::GenerateInitialUnstructGrid (
@@ -190,7 +190,7 @@ void MeshGenerator<3>::GenerateInitialUnstructGrid (
   // create a local triangulation and modify it for the first time
   dealii::Triangulation<2> t_loc;
   // modify the rest of the domain
-  for (int ix=0; ix<ncell_per_dir_[0]; ++ix)
+  for (int ix=0; ix<ncell_per_dir_[0]; ++ix) {
     for (int iy=0; iy<ncell_per_dir_[1]; ++iy) {
       int fuel_id = -1;
       for (int iz=0; iz<ncell_per_dir_[2]; ++iz) {
@@ -219,11 +219,12 @@ void MeshGenerator<3>::GenerateInitialUnstructGrid (
         dealii::GridGenerator::merge_triangulations (t_loc, t_tmp, t_loc);
       }
     }
-    // extrude 2d to 3d
-    dealii::Triangulation<3> t_3d;
-    dealii::GridGenerator::extrude_triangulation (
-        t_loc, ncell_per_dir_[2]+1, axis_max_values_[2], t_3d);
-    tria.copy_triangulation (t_3d);
+  }
+  // extrude 2d to 3d
+  dealii::Triangulation<3> t_3d;
+  dealii::GridGenerator::extrude_triangulation (
+      t_loc, ncell_per_dir_[2]+1, axis_max_values_[2], t_3d);
+  tria.copy_triangulation (t_3d);
 }
 
 template <int dim>

--- a/src/mesh/mesh_generator.cc
+++ b/src/mesh/mesh_generator.cc
@@ -345,7 +345,8 @@ void MeshGenerator<dim>::SetupBoundaryIDs
   for (typename dealii::Triangulation<dim>::active_cell_iterator
        cell=tria.begin_active(); cell!=tria.end(); ++cell)
     if (cell->is_locally_owned())
-      for (int fn=0; fn<dealii::GeometryInfo<dim>::faces_per_cell; ++fn)
+      for (unsigned int fn=0;
+           fn<dealii::GeometryInfo<dim>::faces_per_cell; ++fn)
         if (cell->at_boundary(fn)) {
           dealii::Point<dim> ct = cell->face(fn)->center();
           // x-axis boundaries
@@ -409,7 +410,7 @@ void MeshGenerator<dim>::PreprocessReflectiveBC (
     AssertThrow (strings.size()>0,
         dealii::ExcMessage("reflective boundary names have to be entered"));
     std::set<int> tmp;
-    for (int i=0; i<strings.size (); ++i) {
+    for (unsigned int i=0; i<strings.size (); ++i) {
       AssertThrow(bd_names_to_id.find(strings[i])!=bd_names_to_id.end(),
           dealii::ExcMessage("Invalid reflective boundary name: use xmin, xmax, etc."));
       tmp.insert (bd_names_to_id[strings[i]]);
@@ -446,7 +447,7 @@ void MeshGenerator<dim>::InitializeRelativePositionToIDMap (
         int z = ct / ncell_y;
         std::vector<std::string> strings =
             dealii::Utilities::split_string_list (line, ' ');
-        AssertThrow (strings.size()==ncell_x,
+        AssertThrow (strings.size()==static_cast<size_t>(ncell_x),
             dealii::ExcMessage("Entries of material ID per row must be ncell_x"));
         for (int x=0; x<ncell_x; ++x) {
           std::vector<int> tmp = {x};
@@ -470,7 +471,7 @@ void MeshGenerator<dim>::InitializeRelativePositionToIDMap (
           int z = ct / ncell_y;
           std::vector<std::string> strings =
               dealii::Utilities::split_string_list (line, ' ');
-          AssertThrow (strings.size()==ncell_x,
+          AssertThrow (strings.size()==static_cast<size_t>(ncell_x),
               dealii::ExcMessage("Entries of material ID per row must be ncell_x"));
           for (int x=0; x<ncell_x; ++x) {
             std::vector<int> tmp = {x};
@@ -524,7 +525,8 @@ void MeshGenerator<2>::SetManifoldsAndRefine (dealii::Triangulation<2> &tria) {
         dealii::Point<2> cell_ctr_xy (cell->center()[0], cell->center()[1]);
         if (cell_ctr_xy.distance(pin_ctr_xy)<rod_radius_) {
           int x=relative_position[0], y=relative_position[1];
-          for (int vn=0; vn<dealii::GeometryInfo<2>::vertices_per_cell; ++vn) {
+          for (unsigned  vn=0;
+               vn<dealii::GeometryInfo<2>::vertices_per_cell; ++vn) {
             dealii::Point<2> vertex_xy(cell->vertex(vn)[0], cell->vertex(vn)[1]);
             double dist = vertex_xy.distance(pin_ctr_xy);
             if (std::fabs(dist-rod_radius_)<1.0e-14) {
@@ -540,7 +542,7 @@ void MeshGenerator<2>::SetManifoldsAndRefine (dealii::Triangulation<2> &tria) {
   tria.refine_global (global_refinements_);
 
   // reset the manifolds to avoid error from deal.II design defect of manifold
-  tria.set_manifold (INT_MAX);
+  tria.reset_manifold (INT_MAX);
 }
 
 template <>
@@ -579,7 +581,7 @@ void MeshGenerator<3>::SetManifoldsAndRefine (dealii::Triangulation<3> &tria) {
   // perform the refinement
   tria.refine_global (global_refinements_);
   // reset the manifolds to avoid error from deal.II design defect of manifold
-  tria.set_manifold (INT_MAX);
+  tria.reset_manifold (INT_MAX);
 }
 
 template <>

--- a/src/mesh/mesh_generator.cc
+++ b/src/mesh/mesh_generator.cc
@@ -447,7 +447,7 @@ void MeshGenerator<dim>::InitializeRelativePositionToIDMap (
         int z = ct / ncell_y;
         std::vector<std::string> strings =
             dealii::Utilities::split_string_list (line, ' ');
-        AssertThrow (strings.size()==static_cast<size_t>(ncell_x),
+        AssertThrow (static_cast<int>(strings.size()) == ncell_x,
             dealii::ExcMessage("Entries of material ID per row must be ncell_x"));
         for (int x=0; x<ncell_x; ++x) {
           std::vector<int> tmp = {x};
@@ -471,7 +471,7 @@ void MeshGenerator<dim>::InitializeRelativePositionToIDMap (
           int z = ct / ncell_y;
           std::vector<std::string> strings =
               dealii::Utilities::split_string_list (line, ' ');
-          AssertThrow (strings.size()==static_cast<size_t>(ncell_x),
+          AssertThrow (static_cast<int>(strings.size())==ncell_x,
               dealii::ExcMessage("Entries of material ID per row must be ncell_x"));
           for (int x=0; x<ncell_x; ++x) {
             std::vector<int> tmp = {x};

--- a/src/mesh/mesh_generator.h
+++ b/src/mesh/mesh_generator.h
@@ -84,7 +84,7 @@ class MeshGenerator {
    \param tria Triangulation object.
    \return Void. Modify tria in place.
    */
-  void GenerateInitialUnstructGrid (dealii::Triangulation<dim> &tria);
+  void GenerateInitialUnstructGrid (dealii::Triangulation<dim> &);
 
   /*!
    Function to generate a non-fuel pin model for 2D. 4 cells are created for the

--- a/src/test_main.cc
+++ b/src/test_main.cc
@@ -1,36 +1,57 @@
 #include <unistd.h>
 #include <getopt.h>
+#include <vector>
 
-#include <deal.II/base/mpi.h>
+//#include <deal.II/base/mpi.h>
 #include "gtest/gtest.h"
 
 #include "test_helpers/gmock_wrapper.h"
 #include "test_helpers/bart_test_helper.h"
 
-int main(int argc, char* argv[]) {
+int main(int argc, char** argv) {
   // Parse optional arguments
-  ::testing::InitGoogleMock(&argc, argv);
 
-  int option_index = 0;
+  int option_index = 0, c = 0;
+  bool use_mpi = false;
 
   const struct option longopts[] =
   {
-    {"report", no_argument, nullptr, 'r'}
+    {"report", no_argument, NULL, 'r'},
+    {"mpi",    no_argument, NULL, 'm'},
+    {NULL,     0,           NULL,   0}
   };
 
-  int c;
-  while ((c = getopt_long (argc, argv, "rd:", longopts, &option_index)) != -1) {
+  while ((c = getopt_long (argc, argv, "rmd:", longopts, &option_index)) != -1) {
     switch(c) {
-      case 'r':
+      case 'r': {
         btest::GlobalBARTTestHelper().SetReport(true);
         break;
-      case 'd':
+      }
+      case 'd': {
         btest::GlobalBARTTestHelper().SetGoldFilesDirectory(optarg);
         break;
+      }
+      case 'm': {
+        use_mpi = true;
+        break;
+      }
       default:
         break;
     }
   }
+
+  std::vector<const char*> new_argv(argv, argv + argc);
+  if (use_mpi) {
+    new_argv.push_back("--gtest_filter=*MPI*");
+  } else {
+    new_argv.push_back("--gtest_filter=-*MPI*");
+  }
+  new_argv.push_back(nullptr);
+  argv = const_cast<char**>(new_argv.data());
+  argc += 1;
+
+  ::testing::InitGoogleMock(&argc, argv);
+  
   return RUN_ALL_TESTS();
 }
 


### PR DESCRIPTION
This pull request provides the following fixes:
- Properly deletes raw pointers in BARTDriver
- Clears compiler warnings by:
  - Removing unused parameters from many functions
  - Replacing index-based loops with iterators where possible
  - Setting index-based loops to use `unsigned int` (see note)
  - Using `static_cast<int>` to cast size values to integers for comparison with integers
- Changes name of executable from `xtrans` to `bart`
- Adds a flag to `bart_test` to run MPI tests, otherwise non-MPI tests are run

*Note*: The Google C++ standard warns against using `unsigned int` when not appropriate, and to replace index-based loops with iterators where possible. This implies that when iterators can't be used, `unsigned` is still appropriate.
