### PR TITLE
Test filter and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ BART uses the following applications and libraries for testing:
 The development work is led by [Dr. Rachel Slaybaugh](https://github.com/rachelslaybaugh). Graduate students actively involved in the development include:
 - [Joshua Rehak](https://github.com/jsrehak/)
 
-Previous developers include [Dr. Weixiong Zheng](https://github.com/weixiong-zheng-berkeley/).
+Previous developers include 
+- [Dr. Weixiong Zheng](https://github.com/weixiong-zheng-berkeley/).
+- [Marissa Ramirez Zweiger](https://github.com/mzweig/)
 
 ## What is the rationale behind BART?
 ### BART is a finite element method based code

--- a/README.md
+++ b/README.md
@@ -1,52 +1,64 @@
-| `master` | `dev` | `restart` |
-|----------|-------|-----------|
-|[![Build Status](https://travis-ci.org/SlaybaughLab/BART.svg?branch=master)](https://travis-ci.org/SlaybaughLab/BART)|[![Build Status](https://travis-ci.org/SlaybaughLab/BART.svg?branch=dev)](https://travis-ci.org/SlaybaughLab/BART)|[![Build Status](https://travis-ci.org/SlaybaughLab/BART.svg?branch=restart)](https://travis-ci.org/SlaybaughLab/BART)  [![Codecov](https://codecov.io/gh/SlaybaughLab/BART/branch/restart/graph/badge.svg)](https://codecov.io/gh/SlaybaughLab/BART/branch/restart)|
-
-
+| `master` | `dev` |
+|----------|-------|
+|[![Build Status](https://travis-ci.org/SlaybaughLab/BART.svg?branch=master)](https://travis-ci.org/SlaybaughLab/BART)[![Codecov](https://codecov.io/gh/SlaybaughLab/BART/branch/master/graph/badge.svg)](https://codecov.io/gh/SlaybaughLab/BART/branch/master)|[![Build Status](https://travis-ci.org/SlaybaughLab/BART.svg?branch=dev)](https://travis-ci.org/SlaybaughLab/BART)[![Codecov](https://codecov.io/gh/SlaybaughLab/BART/branch/dev/graph/badge.svg)](https://codecov.io/gh/SlaybaughLab/BART/branch/dev)|
 
 # Bay Area Radiation Transport (BART)
+
 ## What is BART for?
-Bay Area Radiation Transport, AKA BART, is a C++ based research-purpose code for parallel radiation transport computation in nuclear reactor applications. BART is being actively developed at Computational Neutronics group in Nuclear Engineering at University of California, Berkeley.
+
+Bay Area Radiation Transport (BART), is a C++-based research-purpose
+code for parallel radiation transport computation in nuclear reactor
+applications. BART is under active developed by the Computational
+Neutronics group in Nuclear Engineering at University of California,
+Berkeley.
 
 ## How do we manage the development?
+
 ### Documentation
-BART documents everything implemented for functionality using [doxygen](http://www.stack.nl/~dimitri/doxygen/). We believe that we and future developers will be thankful to ourselves for documenting today at some time in the future. 
+
+BART documentation is generated using [doxygen](http://www.stack.nl/~dimitri/doxygen/).
 
 ### Test-driven development
-BART in the [restart run](https://github.com/SlaybaughLab/BART/tree/restart) is driven by the principle of testing everything necessary. Specifically, we use:
-- [Travis CI](https://circleci.com/?utm_source=gnb&utm_medium=SEM&utm_campaign=SEM-gnb-400-Eng-ni&utm_content=SEM-gnb-400-Eng-ni-Travis_CI&gclid=Cj0KCQjwkpfWBRDZARIsAAfeXaqgCfU-RRPCdyxlvRTTGYw2qT31LlLfwIw_1OXVUw5gYvJSZhcHG9saAm_nEALw_wcB) for continuous integration;
-- [CTest](https://cmake.org/Wiki/CMake/Testing_With_CTest) for unit testings requiring MPI;
-- [Google Test](https://github.com/google/googletest) for all other serial unit testings.
+BART uses the following applications and libraries for testing:
+- [Travis CI](https://travis-ci.org) for continuous integration
+- [CTest](https://cmake.org/Wiki/CMake/Testing_With_CTest) for unit testings requiring MPI
+- [Google Test](https://github.com/google/googletest) for all other
+  serial unit testings.
+- [Codecov](https://codecov.io/) for code coverage of serial tests.
 
-### Agile management
-We are gradually immersing ourselves in the principle of agile management using [Jira](https://www.atlassian.com/software/jira?aceid=&adposition=1t1&adgroup=9124375582&campaign=189421462&creative=256725234926&device=c&keyword=jira&matchtype=e&network=g&placement=&ds_kids=p19481846873&gclid=Cj0KCQjwkpfWBRDZARIsAAfeXarkxD2j0JPwTTaH07dxEy8nVbZgK7U_Uj8hDx7j2uyUBXl29zrtoQQaAshhEALw_wcB&gclsrc=aw.ds) to improve our BART development tracking.
+<!-- ### Agile management -->
+<!-- We are gradually immersing ourselves in the principle of agile management using [Jira](https://www.atlassian.com/software/jira?aceid=&adposition=1t1&adgroup=9124375582&campaign=189421462&creative=256725234926&device=c&keyword=jira&matchtype=e&network=g&placement=&ds_kids=p19481846873&gclid=Cj0KCQjwkpfWBRDZARIsAAfeXarkxD2j0JPwTTaH07dxEy8nVbZgK7U_Uj8hDx7j2uyUBXl29zrtoQQaAshhEALw_wcB&gclsrc=aw.ds) to improve our BART development tracking. -->
 
-## Who do the hard work?
-The development work is led by [Dr. Weixiong Zheng](https://github.com/weixiong-zheng-berkeley/) and [Dr. Rachel Slaybaugh](https://github.com/rachelslaybaugh). Graduate students actively involved in the development include:
+## Developers
+The development work is led by [Dr. Rachel Slaybaugh](https://github.com/rachelslaybaugh). Graduate students actively involved in the development include:
 - [Joshua Rehak](https://github.com/jsrehak/)
-- [Marissa Ramirez Zweiger](https://github.com/mzweig/)
 
-In the long term, BART will welcome anyone who has a good idea to participating.
+Previous developers include [Dr. Weixiong Zheng](https://github.com/weixiong-zheng-berkeley/).
 
 ## What is the rationale behind BART?
 ### BART is a finite element method based code
 BART is based off the general purpose finite elment [deal.II](http://www.dealii.org/). It aims to solve first and second-order forms of linear Boltzmann equation for nuclear reactor applications using continuous/discontinuous finite element methods for spatial discretization with existing/developing acceleration methods. BART uses discrete ordinates method for angular discretization. 
 
 ### Parallelism in meshing and linear algebra
-BART is using MPI for parallelism. BART is designed for computation on distributed memory system:
+BART uses MPI for parallelism and is designed for computation on distributed memory system:
 - By utilizing distributed triangulation enabled by [p4est](https://www.mcs.anl.gov/petsc/) library wrapped in deal.II, BART can automatically partition the mesh by however many number of processors requested and distribute the triangulation onto different processors.
 - BART heavily depends on [PETSc](https://www.mcs.anl.gov/petsc/) by utilizing deal.II wrappers of PETSc data structure. Therefore, all the parallel-supported functionalities in PETSc (if wrapped by deal.II) can be invoked by BART. This includes parallel sparse matrix, parallel vectors and parallel preconditioners/algebraic solvers.
 
-### General dimensionality
-BART was initially implemented for 2D and 3D for parallel computation. In the [restart branch](https://github.com/SlaybaughLab/BART/tree/restart), the functionality is generalized to 1D with serial settings.
+### Supported Transport Equation forms
+
+Bart supports the following forms of the transport equation:
+
+- Self Adjoint Angular Flux
+- Even Parity
+
+More forms of the transport equation and accelleration methods are an
+area of active development.
 
 ### Meshing capability
-Originally, BART was implemented for homogenized mesh using rectangle mesh in 2D and regular cubois mesh in 3D. In the [restart branch](https://github.com/SlaybaughLab/BART/tree/restart), some thrilling new features are implemented. Overall, we have:
+Supported meshes in BART include:
 - Hyper-rectangular mesh in 1/2/3D;
 - Fuel pin-resolved curvilinear mesh in 2D;
 - Fuel pin-resolved curvilinear mesh in 3D based on extrusion.
-
-The thrilling part is that pin-resolved meshing does not require third-party library, e.g. Cubit and GMSH but rather similar to regular homogenized mesh.
 
 Part of the work also contributes to development version of [deal.II](http://www.dealii.org/).
 

--- a/src/test_main.cc
+++ b/src/test_main.cc
@@ -13,15 +13,17 @@ int main(int argc, char** argv) {
 
   int option_index = 0, c = 0;
   bool use_mpi = false;
+  std::string filter = "";
 
   const struct option longopts[] =
   {
+    {"filter", no_argument, NULL, 'f'},
     {"report", no_argument, NULL, 'r'},
     {"mpi",    no_argument, NULL, 'm'},
     {NULL,     0,           NULL,   0}
   };
 
-  while ((c = getopt_long (argc, argv, "rmd:", longopts, &option_index)) != -1) {
+  while ((c = getopt_long (argc, argv, "rmd:f:", longopts, &option_index)) != -1) {
     switch(c) {
       case 'r': {
         btest::GlobalBARTTestHelper().SetReport(true);
@@ -35,17 +37,25 @@ int main(int argc, char** argv) {
         use_mpi = true;
         break;
       }
+      case 'f': {
+        filter = optarg;
+        break;
+      }
       default:
         break;
     }
   }
 
   std::vector<const char*> new_argv(argv, argv + argc);
-  if (use_mpi) {
-    new_argv.push_back("--gtest_filter=*MPI*");
+  if (filter != "") {
+    filter = "--gtest_filter=" + filter;
+    new_argv.push_back(filter.c_str());
+  } else if (use_mpi) {
+      new_argv.push_back("--gtest_filter=*MPI*");
   } else {
     new_argv.push_back("--gtest_filter=-*MPI*");
   }
+
   new_argv.push_back(nullptr);
   argv = const_cast<char**>(new_argv.data());
   argc += 1;


### PR DESCRIPTION
Updates `bart_test` to add the filter option (`-f` or `--filter`) to filter tests. This will override the `-m, --mpi` flag that also uses the google test filter functionality. Closes #112.

Updates the readme in support of closing the `restart` branch and merging into master.