### PR TITLE
Hotfix: replaced instantiation of ScalarMoment calculator with call to factory

### DIFF
--- a/src/framework/builder/cfem_framework_builder.cc
+++ b/src/framework/builder/cfem_framework_builder.cc
@@ -96,9 +96,9 @@ std::unique_ptr<FrameworkI> CFEM_FrameworkBuilder<dim>::BuildFramework(
   // Build reporter
   std::shared_ptr<ConvergenceReporter> reporter(std::move(BuildConvergenceReporter()));
 
-  // Scalar Quadrature
-  using MomentCalculator = quadrature::calculators::ScalarMoment;
-  auto moment_calculator_ptr = std::make_unique<MomentCalculator>();
+  // Moment calculator
+  auto moment_calculator_ptr = quadrature::factory::MakeMomentCalculator<dim>(
+      quadrature::MomentCalculatorImpl::kScalarMoment);
 
   // Solution group
   auto solution_ptr =


### PR DESCRIPTION
This hotfix should have been included in the last pull request and replaces a direct instantiation of `quadrature::calculators::ScalarMoment` with a call to the appropriate factory.