### PR TITLE
Hotfix: MPI solve master file output

### DIFF
--- a/src/framework/framework.cc
+++ b/src/framework/framework.cc
@@ -33,12 +33,21 @@ void Framework::SolveSystem() {
 
 void Framework::OutputResults(std::ostream &output_stream) {
   AssertThrow(results_output_ptr_ != nullptr,
-              dealii::ExcMessage("Results output poitner is null"));
+              dealii::ExcMessage("Results output pointer is null"));
   AssertThrow(output_stream.good(),
               dealii::ExcMessage("Bad stream passed to OutputResults"));
 
   results_output_ptr_->AddData(*system_ptr_);
   results_output_ptr_->WriteData(output_stream);
+}
+
+void Framework::OutputMasterFile(std::ostream &output_stream,
+                                 const std::vector<std::string>& filenames,
+                                 const int process_id) {
+  if (process_id == 0) {
+    results_output_ptr_->WriteMasterFile(output_stream,
+                                         filenames);
+  }
 }
 
 } // namespace framework

--- a/src/framework/framework.h
+++ b/src/framework/framework.h
@@ -31,6 +31,10 @@ class Framework : public FrameworkI {
 
   void OutputResults(std::ostream& output_stream);
 
+  void OutputMasterFile(std::ostream& output_stream,
+                        const std::vector<std::string>& filenames,
+                        const int process_id);
+
   Initializer* initializer_ptr() const {
     return initializer_ptr_.get();
   }

--- a/src/framework/framework_i.h
+++ b/src/framework/framework_i.h
@@ -15,6 +15,9 @@ class FrameworkI {
   virtual void SolveSystem() = 0;
   virtual system::System* system() const = 0;
   virtual void OutputResults(std::ostream& output_stream) = 0;
+  virtual void OutputMasterFile(std::ostream& output_stream,
+                                const std::vector<std::string>& filenames,
+                                const int process_id) = 0;
 };
 
 } // namespace framework

--- a/src/results/output_dealii_vtu.cc
+++ b/src/results/output_dealii_vtu.cc
@@ -32,6 +32,13 @@ void OutputDealiiVtu<dim>::WriteData(std::ostream &output_stream) const {
   data_out_.write_vtu(output_stream);
 }
 
+template<int dim>
+void OutputDealiiVtu<dim>::WriteMasterFile(
+    std::ostream &output_stream,
+    std::vector<std::string> filenames) const {
+  data_out_.write_pvtu_record(output_stream, filenames);
+}
+
 template class OutputDealiiVtu<1>;
 template class OutputDealiiVtu<2>;
 template class OutputDealiiVtu<3>;

--- a/src/results/output_dealii_vtu.h
+++ b/src/results/output_dealii_vtu.h
@@ -19,6 +19,8 @@ class OutputDealiiVtu : public OutputI {
 
   void AddData(system::System &to_output) override;
   void WriteData(std::ostream &output_stream) const override;
+  void WriteMasterFile(std::ostream &output_stream,
+                       std::vector<std::string> filenames) const override;
 
   domain::DefinitionI<dim>* domain_ptr() const { return domain_ptr_.get(); };
 

--- a/src/results/output_i.h
+++ b/src/results/output_i.h
@@ -16,7 +16,8 @@ class OutputI {
   virtual ~OutputI() = default;
   virtual void AddData(system::System &to_output) = 0;
   virtual void WriteData(std::ostream &output_stream) const = 0;
-  // virtual void ClearData() = 0;
+  virtual void WriteMasterFile(std::ostream &output_stream,
+                               std::vector<std::string> filenames) const = 0;
 };
 
 } // namespace results

--- a/src/results/tests/output_mock.h
+++ b/src/results/tests/output_mock.h
@@ -12,8 +12,10 @@ namespace results {
 
 class OutputMock : public OutputI {
  public:
-  MOCK_METHOD1(AddData, void(system::System&));
-  MOCK_CONST_METHOD1(WriteData, void(std::ostream&));
+  MOCK_METHOD(void, AddData, (system::System&), (override));
+  MOCK_METHOD(void, WriteData, (std::ostream&), (override, const));
+  MOCK_METHOD(void, WriteMasterFile, (std::ostream &output_stream,
+      std::vector<std::string> filenames), (override, const));
 };
 
 } // namespace results


### PR DESCRIPTION
This hotfix adds the master file output so that results of MPI solves can be read using programs such as paraview. Closes #160 