### PR TITLE
deal.ii 9.1.1 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,30 @@ notifications:
 
 language: cpp
 
+env:
+ global:
+  - DOCKER_TAG=v9.1.0
+
 services:
  - docker
 
 before_install:
- - sudo docker pull jsrehak/bart
+ - sudo docker pull jsrehak/bart:$DOCKER_TAG
  - ci_env=`bash <(curl -s https://codecov.io/env)`
 
 install:
- - sudo docker run jsrehak/bart
+ - sudo docker run jsrehak/bart:$DOCKER_TAG
  - id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
  - sudo docker cp ../BART $id:/home/bart
  - id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
- - sudo docker commit $id jsrehak/bart
- - sudo docker run $ci_env -it -u="root" -d -w="/home/bart/BART" --name bart jsrehak/bart
+ - sudo docker commit $id jsrehak/bart:$DOCKER_TAG
+ - sudo docker run $ci_env -it -u="root" -d -w="/home/bart/BART" --name bart jsrehak/bart:$DOCKER_TAG
 
 script:
  - docker exec bart cmake .
  - docker exec bart make -j4
  - docker exec bart bash -c "./bart_test"
- - docker exec bart bash -c "mpirun -np 2 --allow-run-as-root ./bart_test --mpi -l 0"
+ - docker exec bart bash -c "mpirun -np 2 --allow-run-as-root --oversubscribe ./bart_test --mpi -l 0"
 
 after_success:
  - docker exec bart bash -c "./coverage.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: cpp
 
 env:
  global:
-  - DOCKER_TAG=v9.1.0
+  - DOCKER_TAG=v9.1.1
 
 services:
  - docker

--- a/src/convergence/moments/single_moment_checker_l1_norm.cc
+++ b/src/convergence/moments/single_moment_checker_l1_norm.cc
@@ -9,7 +9,7 @@ namespace moments {
 bool SingleMomentCheckerL1Norm::CheckIfConverged(
     const system::moments::MomentVector &current_iteration,
     const system::moments::MomentVector &previous_iteration) {
-  system::moments::MomentVector difference{current_iteration};
+  system::moments::MomentVector difference(current_iteration);
   difference -= previous_iteration;
   delta_ = difference.l1_norm()/current_iteration.l1_norm();
   is_converged_ = delta_ <= max_delta_;

--- a/src/domain/definition.h
+++ b/src/domain/definition.h
@@ -7,7 +7,7 @@
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/iterator_range.h>
 #include <deal.II/distributed/tria.h>
-#include <deal.II/lac/constraint_matrix.h>
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 #include "domain/definition_i.h"
@@ -132,7 +132,7 @@ class Definition : public DefinitionI<dim> {
   dealii::IndexSet locally_relevant_dofs_;
 
   /*! Constraint matrix */
-  dealii::ConstraintMatrix constraint_matrix_;
+  dealii::AffineConstraints<double> constraint_matrix_;
 
   /*! Dynamic sparsity pattern for MPI matrices */
   dealii::DynamicSparsityPattern dynamic_sparsity_pattern_;

--- a/src/formulation/angular/tests/self_adjoint_angular_flux_test.cc
+++ b/src/formulation/angular/tests/self_adjoint_angular_flux_test.cc
@@ -77,7 +77,7 @@ class FormulationAngularSelfAdjointAngularFluxTest :
                                    0.75*fission_test_factor_,
                                    0.5*fission_test_factor_,
                                    fission_test_factor_}.begin()}}};
-  system::moments::MomentVector group_0_moment_{2}, group_1_moment_{2};
+  system::moments::MomentVector group_0_moment_, group_1_moment_;
   system::moments::MomentsMap out_group_moments_;
   const std::vector<double> group_0_moment_values_{0.75, 0.75};
   const std::vector<double> group_1_moment_values_{1.0, 1.0};
@@ -95,6 +95,9 @@ class FormulationAngularSelfAdjointAngularFluxTest :
 template <typename DimensionWrapper>
 void FormulationAngularSelfAdjointAngularFluxTest<DimensionWrapper>::SetUp() {
   this->SetUpDealii();
+
+  group_0_moment_.reinit(2);
+  group_1_moment_.reinit(2);
 
   // Make mocks and set up
   mock_finite_element_ptr_ = std::make_shared<NiceMock<FiniteElementType>>();

--- a/src/formulation/scalar/tests/diffusion_test.cc
+++ b/src/formulation/scalar/tests/diffusion_test.cc
@@ -335,10 +335,8 @@ TEST_F(FormulationCFEMDiffusionTest, FillBoundaryTermTestVacuum) {
 }
 
 TEST_F(FormulationCFEMDiffusionTest, FillCellFixedSource) {
-  std::vector<double> expected_values{6, 15};
 
-  dealii::Vector<double> expected_vector{expected_values.begin(),
-                                         expected_values.end()};
+  dealii::Vector<double> expected_vector{6, 15};
   dealii::Vector<double> test_vector(2);
 
   formulation::scalar::Diffusion<2> test_diffusion(fe_mock_ptr,
@@ -376,21 +374,15 @@ TEST_F(FormulationCFEMDiffusionTest, FillFissionSourceTest) {
   /* Make out-group moments (specifically in-group values in this are different
    * This is a somewhat tortured process due to the way dealii::Vectors are
    * defined (system::moments::MomentVector is an alias) */
-  std::vector<double> group_0_moment_values{0.75, 0.75};
   std::vector<double> group_1_moment_values{1.0, 1.0};
-  system::moments::MomentVector group_0_moment{group_0_moment_values.begin(),
-                                    group_0_moment_values.end()};
-  system::moments::MomentVector group_1_moment{group_1_moment_values.begin(),
-                                    group_1_moment_values.end()};
+  system::moments::MomentVector group_0_moment{0.75, 0.75};
+  system::moments::MomentVector group_1_moment{1.0, 1.0};
   system::moments::MomentsMap out_group_moments;
   out_group_moments[{0,0,0}] = group_0_moment;
   out_group_moments[{1,0,0}] = group_1_moment;
 
   // Expected answer
-  std::vector<double> expected_values{5,
-                                      12.5};
-  dealii::Vector<double> expected_vector{expected_values.begin(),
-                                         expected_values.end()};
+  dealii::Vector<double> expected_vector{5.0, 12.5};
 
   EXPECT_CALL(*fe_mock_ptr, SetCell(_))
       .Times(1);
@@ -423,10 +415,10 @@ TEST_F(FormulationCFEMDiffusionTest, FillScatteringSourceTest) {
    * defined (system::moments::MomentVector is an alias) */
   std::vector<double> group_0_moment_values{0.75, 0.75};
   std::vector<double> group_1_moment_values{1.0, 1.0};
-  system::moments::MomentVector group_0_moment{group_0_moment_values.begin(),
-                                    group_0_moment_values.end()};
-  system::moments::MomentVector group_1_moment{group_1_moment_values.begin(),
-                                    group_1_moment_values.end()};
+  system::moments::MomentVector group_0_moment(group_0_moment_values.begin(),
+                                               group_0_moment_values.end());
+  system::moments::MomentVector group_1_moment(group_1_moment_values.begin(),
+                                               group_1_moment_values.end());
   system::moments::MomentsMap out_group_moments;
   out_group_moments[{0,0,0}] = group_0_moment;
   out_group_moments[{1,0,0}] = group_1_moment;
@@ -434,12 +426,12 @@ TEST_F(FormulationCFEMDiffusionTest, FillScatteringSourceTest) {
   // Expected solutions
   std::vector<double> expected_group_0_values{3.0,
                                               7.5};
-  dealii::Vector<double> expected_group_0_vector{expected_group_0_values.begin(),
-                                                 expected_group_0_values.end()};
+  dealii::Vector<double> expected_group_0_vector(expected_group_0_values.begin(),
+                                                 expected_group_0_values.end());
   std::vector<double> expected_group_1_values{3.375,
                                               8.4375};
-  dealii::Vector<double> expected_group_1_vector{expected_group_1_values.begin(),
-                                                 expected_group_1_values.end()};
+  dealii::Vector<double> expected_group_1_vector(expected_group_1_values.begin(),
+                                                 expected_group_1_values.end());
   std::array<dealii::Vector<double>, 2> expected_vectors{
       expected_group_0_vector,
       expected_group_1_vector};

--- a/src/formulation/updater/tests/boundary_conditions_updater_mock.h
+++ b/src/formulation/updater/tests/boundary_conditions_updater_mock.h
@@ -1,0 +1,26 @@
+#ifndef BART_SRC_FORMULATION_UPDATER_TESTS_BOUNDARY_CONDITIONS_UPDATER_MOCK_H_
+#define BART_SRC_FORMULATION_UPDATER_TESTS_BOUNDARY_CONDITIONS_UPDATER_MOCK_H_
+
+#include "formulation/updater/boundary_conditions_updater_i.h"
+#include "test_helpers/gmock_wrapper.h"
+
+namespace bart {
+
+namespace formulation {
+
+namespace updater {
+
+class BoundaryConditionsUpdaterMock : public BoundaryConditionsUpdaterI {
+ public:
+  MOCK_METHOD(void, UpdateBoundaryConditions,
+      (system::SystemWithAngularSolution&, system::EnergyGroup,
+          quadrature::QuadraturePointIndex), (override));
+};
+
+} // namespace updater
+
+} // namespace formulation
+
+} // namespace bart
+
+#endif //BART_SRC_FORMULATION_UPDATER_TESTS_BOUNDARY_CONDITIONS_UPDATER_MOCK_H_

--- a/src/framework/builder/framework_builder.cc
+++ b/src/framework/builder/framework_builder.cc
@@ -164,7 +164,7 @@ auto FrameworkBuilder<dim>::BuildConvergenceReporter()
   int this_process = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   auto pout_ptr = std::make_unique<dealii::ConditionalOStream>(std::cout, this_process == 0);
   return_ptr = std::make_unique<Reporter>(std::move(pout_ptr));
-  return std::move(return_ptr);
+  return return_ptr;
 }
 
 template<int dim>
@@ -431,7 +431,7 @@ auto FrameworkBuilder<dim>::BuildMomentConvergenceChecker(
   auto return_ptr = std::make_unique<FinalCheckerType>(
       std::move(single_checker_ptr));
   return_ptr->SetMaxIterations(max_iterations);
-  return std::move(return_ptr);
+  return return_ptr;
 }
 
 template<int dim>
@@ -473,7 +473,7 @@ auto FrameworkBuilder<dim>::BuildParameterConvergenceChecker(
       std::move(single_checker_ptr));
   return_ptr->SetMaxIterations(max_iterations);
 
-  return std::move(return_ptr);
+  return return_ptr;
 }
 
 template<int dim>
@@ -509,7 +509,7 @@ auto FrameworkBuilder<dim>::BuildQuadratureSet(ParametersType problem_parameters
   quadrature::factory::FillQuadratureSet<dim>(return_ptr.get(),
                                               quadrature_points);
 
-  return std::move(return_ptr);
+  return return_ptr;
 }
 
 template <int dim>

--- a/src/framework/builder/framework_builder.h
+++ b/src/framework/builder/framework_builder.h
@@ -185,7 +185,7 @@ class FrameworkBuilder {
 
   template <typename T>
   inline std::shared_ptr<T> Shared(std::unique_ptr<T> to_convert_ptr) {
-    return std::move(to_convert_ptr);
+    return to_convert_ptr;
   }
   std::string ReadMappingFile(std::string filename);
 

--- a/src/quadrature/calculators/tests/scalar_moment_test.cc
+++ b/src/quadrature/calculators/tests/scalar_moment_test.cc
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include <deal.II/base/mpi.h>
-#include <deal.II/lac/petsc_parallel_vector.h>
+#include <deal.II/lac/petsc_vector.h>
 
 #include "system/system_types.h"
 #include "system/moments/spherical_harmonic_types.h"

--- a/src/quadrature/calculators/tests/spherical_harmonic_zeroth_moment_test.cc
+++ b/src/quadrature/calculators/tests/spherical_harmonic_zeroth_moment_test.cc
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include <deal.II/base/mpi.h>
-#include <deal.II/lac/petsc_parallel_vector.h>
+#include <deal.II/lac/petsc_vector.h>
 
 #include "system/system_types.h"
 #include "system/moments/spherical_harmonic_types.h"

--- a/src/solver/tests/gmres_test.cc
+++ b/src/solver/tests/gmres_test.cc
@@ -4,7 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <deal.II/base/tensor.h>
-#include <deal.II/lac/petsc_parallel_vector.h>
+#include <deal.II/lac/petsc_vector.h>
 
 #include "test_helpers/test_helper_functions.h"
 #include "test_helpers/gmock_wrapper.h"

--- a/src/system/system_types.h
+++ b/src/system/system_types.h
@@ -5,8 +5,9 @@
 #include <utility>
 
 #include <deal.II/lac/vector.h>
-#include <deal.II/lac/petsc_parallel_sparse_matrix.h>
-#include <deal.II/lac/petsc_parallel_vector.h>
+#include <deal.II/lac/petsc_sparse_matrix.h>
+#include <deal.II/lac/petsc_vector.h>
+
 
 #include "utility/named_type.h"
 

--- a/src/system/terms/tests/linear_term_test.cc
+++ b/src/system/terms/tests/linear_term_test.cc
@@ -3,7 +3,7 @@
 #include <memory>
 #include <unordered_set>
 
-#include <deal.II/lac/petsc_parallel_vector.h>
+#include <deal.II/lac/petsc_vector.h>
 #include <deal.II/base/mpi.h>
 
 #include "system/system_types.h"

--- a/src/test_helpers/dealii_test_domain.h
+++ b/src/test_helpers/dealii_test_domain.h
@@ -11,7 +11,7 @@
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
-#include <deal.II/lac/petsc_parallel_sparse_matrix.h>
+#include <deal.II/lac/petsc_sparse_matrix.h>
 
 #include <gtest/gtest.h>
 

--- a/src/test_helpers/dealii_test_domain.h
+++ b/src/test_helpers/dealii_test_domain.h
@@ -100,7 +100,7 @@ template <int dim>
                     double value = 1);
 
    using Cell = typename dealii::DoFHandler<dim>::active_cell_iterator;
-   dealii::ConstraintMatrix constraint_matrix_;
+   dealii::AffineConstraints<double> constraint_matrix_;
    typename TriangulationType<dim>::type triangulation_;
    dealii::DoFHandler<dim> dof_handler_;
    dealii::FE_Q<dim> fe_;

--- a/src/test_helpers/test_assertions.cc
+++ b/src/test_helpers/test_assertions.cc
@@ -28,8 +28,8 @@ AssertionResult CompareVector(const dealii::Vector<double>& expected,
 AssertionResult CompareVector(const std::vector<double> expected,
                                      const std::vector<double> result,
                                      const double tol) {
-  dealii::Vector<double> expected_vec{expected.begin(), expected.end()};
-  dealii::Vector<double> result_vec{result.begin(), result.end()};
+  dealii::Vector<double> expected_vec(expected.begin(), expected.end());
+  dealii::Vector<double> result_vec(result.begin(), result.end());
   return CompareVector(expected_vec, result_vec, tol);
 }
 

--- a/src/test_helpers/test_assertions.h
+++ b/src/test_helpers/test_assertions.h
@@ -2,7 +2,7 @@
 #define BART_SRC_TEST_HELPERS_TEST_ASSERTIONS_H_
 
 #include <deal.II/lac/vector.h>
-#include <deal.II/lac/petsc_parallel_sparse_matrix.h>
+#include <deal.II/lac/petsc_sparse_matrix.h>
 
 #include "test_helpers/gmock_wrapper.h"
 

--- a/src/test_helpers/tests/test_assertions_test.cc
+++ b/src/test_helpers/tests/test_assertions_test.cc
@@ -10,7 +10,7 @@
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
-#include <deal.II/lac/petsc_parallel_sparse_matrix.h>
+#include <deal.II/lac/petsc_sparse_matrix.h>
 
 #include "test_helpers/dealii_test_domain.h"
 #include "test_helpers/test_helper_functions.h"


### PR DESCRIPTION
This update makes BART compatible with the most recent version of `deal.II`, 9.1.1. There are minor compatibility changes, and a new docker container that is built on ubuntu 20.04 LTE. Also included is a hotfix that resolves many warnings from the building of the `FrameworkBuilder` class.