### PR TITLE
Implementation of SAAF Reflective Boundary Conditions

### DIFF
--- a/src/domain/finite_element/finite_element.cc
+++ b/src/domain/finite_element/finite_element.cc
@@ -53,6 +53,13 @@ std::vector<double> FiniteElement<dim>::ValueAtQuadrature(
 
   return return_vector;
 }
+template<int dim>
+std::vector<double> FiniteElement<dim>::ValueAtFaceQuadrature(
+    const system::MPIVector &mpi_vector) const {
+  std::vector<double> return_vector(n_face_quad_pts(), 0);
+  face_values_->get_function_values(mpi_vector, return_vector);
+  return return_vector;
+}
 
 template class FiniteElement<1>;
 template class FiniteElement<2>;

--- a/src/domain/finite_element/finite_element.cc
+++ b/src/domain/finite_element/finite_element.cc
@@ -47,7 +47,7 @@ template<int dim>
 std::vector<double> FiniteElement<dim>::ValueAtQuadrature(
     const system::moments::MomentVector moment) const {
 
-  std::vector<double> return_vector(finite_element_->dofs_per_cell, 0);
+  std::vector<double> return_vector(n_cell_quad_pts(), 0);
 
   values_->get_function_values(moment, return_vector);
 

--- a/src/domain/finite_element/finite_element.cc
+++ b/src/domain/finite_element/finite_element.cc
@@ -53,15 +53,7 @@ std::vector<double> FiniteElement<dim>::ValueAtQuadrature(
 
   return return_vector;
 }
-template<int dim>
-std::vector<double> FiniteElement<dim>::ValueAtFaceQuadrature(
-    const system::MPIVector &mpi_vector) const {
-  std::vector<double> return_vector(n_face_quad_pts(), 0);
-  dealii::Vector<double> vector_to_interpolate;
-  vector_to_interpolate = mpi_vector;
-  face_values_->get_function_values(vector_to_interpolate, return_vector);
-  return return_vector;
-}
+
 template<int dim>
 std::vector<double> FiniteElement<dim>::ValueAtFaceQuadrature(
     const dealii::Vector<double>& values_at_dofs) const {

--- a/src/domain/finite_element/finite_element.cc
+++ b/src/domain/finite_element/finite_element.cc
@@ -62,6 +62,13 @@ std::vector<double> FiniteElement<dim>::ValueAtFaceQuadrature(
   face_values_->get_function_values(vector_to_interpolate, return_vector);
   return return_vector;
 }
+template<int dim>
+std::vector<double> FiniteElement<dim>::ValueAtFaceQuadrature(
+    const dealii::Vector<double>& values_at_dofs) const {
+  std::vector<double> return_vector(n_face_quad_pts(), 0);
+  face_values_->get_function_values(values_at_dofs, return_vector);
+  return return_vector;
+}
 
 template class FiniteElement<1>;
 template class FiniteElement<2>;

--- a/src/domain/finite_element/finite_element.cc
+++ b/src/domain/finite_element/finite_element.cc
@@ -57,7 +57,9 @@ template<int dim>
 std::vector<double> FiniteElement<dim>::ValueAtFaceQuadrature(
     const system::MPIVector &mpi_vector) const {
   std::vector<double> return_vector(n_face_quad_pts(), 0);
-  face_values_->get_function_values(mpi_vector, return_vector);
+  dealii::Vector<double> vector_to_interpolate;
+  vector_to_interpolate = mpi_vector;
+  face_values_->get_function_values(vector_to_interpolate, return_vector);
   return return_vector;
 }
 

--- a/src/domain/finite_element/finite_element.h
+++ b/src/domain/finite_element/finite_element.h
@@ -77,9 +77,6 @@ class FiniteElement : public FiniteElementI<dim> {
       const system::moments::MomentVector moment) const override;
 
   std::vector<double> ValueAtFaceQuadrature(
-      const system::MPIVector &mpi_vector) const override;
-
-  std::vector<double> ValueAtFaceQuadrature(
       const dealii::Vector<double>& values_at_dofs) const override;
 
  protected:

--- a/src/domain/finite_element/finite_element.h
+++ b/src/domain/finite_element/finite_element.h
@@ -79,6 +79,9 @@ class FiniteElement : public FiniteElementI<dim> {
   std::vector<double> ValueAtFaceQuadrature(
       const system::MPIVector &mpi_vector) const override;
 
+  std::vector<double> ValueAtFaceQuadrature(
+      const dealii::Vector<double>& values_at_dofs) const override;
+
  protected:
   std::shared_ptr<dealii::FiniteElement<dim, dim>> finite_element_;
   std::shared_ptr<dealii::FEValues<dim>> values_;

--- a/src/domain/finite_element/finite_element.h
+++ b/src/domain/finite_element/finite_element.h
@@ -3,6 +3,7 @@
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>
+#include <system/system_types.h>
 
 #include "domain/finite_element/finite_element_i.h"
 
@@ -72,7 +73,15 @@ class FiniteElement : public FiniteElementI<dim> {
     return face_values_->normal_vector(0);
   };
 
-  std::vector<double> ValueAtQuadrature(const system::moments::MomentVector moment) const override;
+  std::vector<double> ValueAtQuadrature(
+      const system::moments::MomentVector moment) const override;
+
+  std::vector<double> ValueAtFaceQuadrature(
+      const system::MPIVector &mpi_vector) const override {
+    std::vector<double> return_vector(finite_element_->dofs_per_cell, 0);
+    face_values_->get_function_values(mpi_vector, return_vector);
+    return return_vector;
+  }
 
  protected:
   std::shared_ptr<dealii::FiniteElement<dim, dim>> finite_element_;

--- a/src/domain/finite_element/finite_element.h
+++ b/src/domain/finite_element/finite_element.h
@@ -77,11 +77,7 @@ class FiniteElement : public FiniteElementI<dim> {
       const system::moments::MomentVector moment) const override;
 
   std::vector<double> ValueAtFaceQuadrature(
-      const system::MPIVector &mpi_vector) const override {
-    std::vector<double> return_vector(finite_element_->dofs_per_cell, 0);
-    face_values_->get_function_values(mpi_vector, return_vector);
-    return return_vector;
-  }
+      const system::MPIVector &mpi_vector) const override;
 
  protected:
   std::shared_ptr<dealii::FiniteElement<dim, dim>> finite_element_;

--- a/src/domain/finite_element/finite_element_i.h
+++ b/src/domain/finite_element/finite_element_i.h
@@ -146,6 +146,9 @@ class FiniteElementI {
    virtual std::vector<double> ValueAtFaceQuadrature(
        const system::MPIVector& mpi_vector) const = 0;
 
+   virtual std::vector<double> ValueAtFaceQuadrature(
+       const dealii::Vector<double>& values_at_dofs) const = 0;
+
   // DealII Finite element object access. These methods access the underlying
   // finite element objects.
   /*! \brief Gets pointer to the underlying finite element object */

--- a/src/domain/finite_element/finite_element_i.h
+++ b/src/domain/finite_element/finite_element_i.h
@@ -5,6 +5,7 @@
 
 #include "domain/domain_types.h"
 #include "system/moments/spherical_harmonic_types.h"
+#include "system/system_types.h"
 
 /*! \brief Interface for a finite element object based on the dealii library.
  *
@@ -136,6 +137,14 @@ class FiniteElementI {
    */
   virtual std::vector<double> ValueAtQuadrature(
       const system::moments::MomentVector moment) const = 0;
+
+  /*! \brief Get the value of an MPI Vector at the cell face quadrature points.
+   *
+   * @param mpi_vector mpi vector to get the face values of.
+   * @return a vector holding the value of the mpi vector at each face quadrature point.
+   */
+   virtual std::vector<double> ValueAtFaceQuadrature(
+       const system::MPIVector& mpi_vector) const = 0;
 
   // DealII Finite element object access. These methods access the underlying
   // finite element objects.

--- a/src/domain/finite_element/finite_element_i.h
+++ b/src/domain/finite_element/finite_element_i.h
@@ -144,9 +144,6 @@ class FiniteElementI {
    * @return a vector holding the value of the mpi vector at each face quadrature point.
    */
    virtual std::vector<double> ValueAtFaceQuadrature(
-       const system::MPIVector& mpi_vector) const = 0;
-
-   virtual std::vector<double> ValueAtFaceQuadrature(
        const dealii::Vector<double>& values_at_dofs) const = 0;
 
   // DealII Finite element object access. These methods access the underlying

--- a/src/domain/finite_element/tests/finite_element_gaussian_test.cc
+++ b/src/domain/finite_element/tests/finite_element_gaussian_test.cc
@@ -200,4 +200,12 @@ TYPED_TEST(DomainFiniteElementGaussianBaseMethodsTest, BaseValueAtQuadrature) {
   this->TestValueAtQuadrature(&test_fe);
 }
 
+TYPED_TEST(DomainFiniteElementGaussianBaseMethodsTest, BaseValueAtFaceQuadrature) {
+  bart::domain::finite_element::FiniteElementGaussian<this->dim> test_fe{
+      problem::DiscretizationType::kDiscontinuousFEM, 2};
+  this->TestValueAtFaceQuadrature(&test_fe);
+}
+
+
+
 } // namespace

--- a/src/domain/finite_element/tests/finite_element_gaussian_test.cc
+++ b/src/domain/finite_element/tests/finite_element_gaussian_test.cc
@@ -206,6 +206,26 @@ TYPED_TEST(DomainFiniteElementGaussianBaseMethodsTest, BaseValueAtFaceQuadrature
   this->TestValueAtFaceQuadrature(&test_fe);
 }
 
+// BASE CLASS MPI TESTS ========================================================
 
+template <typename DimensionWrapper>
+class DomainFiniteElementGaussianBaseMethodsMPITest :
+    public domain::finite_element::testing::DomainFiniteElementBaseDomainTest<DimensionWrapper::value> {
+ protected:
+  static constexpr int dim = DimensionWrapper::value;
+  void SetUp() override {
+    domain::finite_element::testing::DomainFiniteElementBaseDomainTest<dim>::SetUp();
+  }
+};
+
+TYPED_TEST_SUITE(DomainFiniteElementGaussianBaseMethodsMPITest,
+                 bart::testing::AllDimensions);
+
+TYPED_TEST(DomainFiniteElementGaussianBaseMethodsMPITest,
+    BaseValueAtFaceQuadratureMPITest) {
+  bart::domain::finite_element::FiniteElementGaussian<this->dim> test_fe{
+      problem::DiscretizationType::kContinuousFEM, 2};
+  this->TestValueAtFaceQuadrature(&test_fe);
+}
 
 } // namespace

--- a/src/domain/finite_element/tests/finite_element_gaussian_test.cc
+++ b/src/domain/finite_element/tests/finite_element_gaussian_test.cc
@@ -206,26 +206,4 @@ TYPED_TEST(DomainFiniteElementGaussianBaseMethodsTest, BaseValueAtFaceQuadrature
   this->TestValueAtFaceQuadrature(&test_fe);
 }
 
-// BASE CLASS MPI TESTS ========================================================
-
-template <typename DimensionWrapper>
-class DomainFiniteElementGaussianBaseMethodsMPITest :
-    public domain::finite_element::testing::DomainFiniteElementBaseDomainTest<DimensionWrapper::value> {
- protected:
-  static constexpr int dim = DimensionWrapper::value;
-  void SetUp() override {
-    domain::finite_element::testing::DomainFiniteElementBaseDomainTest<dim>::SetUp();
-  }
-};
-
-TYPED_TEST_SUITE(DomainFiniteElementGaussianBaseMethodsMPITest,
-                 bart::testing::AllDimensions);
-
-TYPED_TEST(DomainFiniteElementGaussianBaseMethodsMPITest,
-    BaseValueAtFaceQuadratureMPITest) {
-  bart::domain::finite_element::FiniteElementGaussian<this->dim> test_fe{
-      problem::DiscretizationType::kContinuousFEM, 2};
-  this->TestValueAtFaceQuadrature(&test_fe);
-}
-
 } // namespace

--- a/src/domain/finite_element/tests/finite_element_mock.h
+++ b/src/domain/finite_element/tests/finite_element_mock.h
@@ -45,6 +45,9 @@ class FiniteElementMock : public FiniteElementI<dim> {
 
   MOCK_METHOD(std::vector<double>, ValueAtQuadrature, (const system::moments::MomentVector moment), (const, override));
 
+  MOCK_METHOD(std::vector<double>, ValueAtFaceQuadrature,
+      (const system::MPIVector&), (const, override));
+
   MOCK_METHOD((dealii::FiniteElement<dim, dim>*), finite_element, (), (override));
 
   MOCK_METHOD(dealii::FEValues<dim>*, values, (), (override));

--- a/src/domain/finite_element/tests/finite_element_mock.h
+++ b/src/domain/finite_element/tests/finite_element_mock.h
@@ -48,6 +48,9 @@ class FiniteElementMock : public FiniteElementI<dim> {
   MOCK_METHOD(std::vector<double>, ValueAtFaceQuadrature,
       (const system::MPIVector&), (const, override));
 
+  MOCK_METHOD(std::vector<double>, ValueAtFaceQuadrature,
+      (const dealii::Vector<double>&), (const, override));
+
   MOCK_METHOD((dealii::FiniteElement<dim, dim>*), finite_element, (), (override));
 
   MOCK_METHOD(dealii::FEValues<dim>*, values, (), (override));

--- a/src/domain/finite_element/tests/finite_element_mock.h
+++ b/src/domain/finite_element/tests/finite_element_mock.h
@@ -46,9 +46,6 @@ class FiniteElementMock : public FiniteElementI<dim> {
   MOCK_METHOD(std::vector<double>, ValueAtQuadrature, (const system::moments::MomentVector moment), (const, override));
 
   MOCK_METHOD(std::vector<double>, ValueAtFaceQuadrature,
-      (const system::MPIVector&), (const, override));
-
-  MOCK_METHOD(std::vector<double>, ValueAtFaceQuadrature,
       (const dealii::Vector<double>&), (const, override));
 
   MOCK_METHOD((dealii::FiniteElement<dim, dim>*), finite_element, (), (override));

--- a/src/domain/finite_element/tests/finite_element_test.h
+++ b/src/domain/finite_element/tests/finite_element_test.h
@@ -157,7 +157,6 @@ void DomainFiniteElementBaseDomainTest<dim>::TestValueAtFaceQuadrature(
   dealii::DoFHandler<dim> dof_handler(this->triangulation_);
   dof_handler.distribute_dofs(*test_fe->finite_element());
 
-  auto n_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
   auto this_process = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
 
   dealii::IndexSet locally_owned_dofs;
@@ -181,7 +180,7 @@ void DomainFiniteElementBaseDomainTest<dim>::TestValueAtFaceQuadrature(
         int faces_per_cell = dealii::GeometryInfo<dim>::faces_per_cell;
         for (int face = 0; face < faces_per_cell; ++face) {
           if (cell->face(face)->at_boundary()) {
-            test_fe->SetFace(cell, domain::FaceIndex(face));
+            EXPECT_TRUE(test_fe->SetFace(cell, domain::FaceIndex(face)));
             break;
           }
         }
@@ -191,7 +190,6 @@ void DomainFiniteElementBaseDomainTest<dim>::TestValueAtFaceQuadrature(
   }
 
   auto result_vector = test_fe->ValueAtFaceQuadrature(test_vector);
-
   EXPECT_TRUE(bart::test_helpers::CompareVector(expected_vector, result_vector));
 }
 

--- a/src/domain/finite_element/tests/finite_element_test.h
+++ b/src/domain/finite_element/tests/finite_element_test.h
@@ -154,7 +154,45 @@ void DomainFiniteElementBaseDomainTest<dim>::SetUp() {
 template <int dim>
 void DomainFiniteElementBaseDomainTest<dim>::TestValueAtFaceQuadrature(
     FiniteElement<dim> *test_fe) {
-  EXPECT_TRUE(false);
+  dealii::DoFHandler<dim> dof_handler(this->triangulation_);
+  dof_handler.distribute_dofs(*test_fe->finite_element());
+
+  auto n_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  auto this_process = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  dealii::IndexSet locally_owned_dofs;
+  if (dim > 1) {
+    locally_owned_dofs = dof_handler.locally_owned_dofs();
+  } else {
+    dealii::DoFRenumbering::subdomain_wise(dof_handler);
+    locally_owned_dofs = dealii::DoFTools::locally_owned_dofs_per_subdomain(
+        dof_handler).at(this_process);
+  }
+
+  system::MPIVector test_vector(locally_owned_dofs, MPI_COMM_WORLD);
+  test_vector = 0.5;
+  test_vector.compress(dealii::VectorOperation::insert);
+
+  std::vector<double> expected_vector(test_fe->n_face_quad_pts(), 0.5);
+
+  for (auto cell = dof_handler.begin_active(); cell != dof_handler.end(); ++cell) {
+    if (cell->is_locally_owned()) {
+      if (cell->at_boundary()) {
+        int faces_per_cell = dealii::GeometryInfo<dim>::faces_per_cell;
+        for (int face = 0; face < faces_per_cell; ++face) {
+          if (cell->face(face)->at_boundary()) {
+            test_fe->SetFace(cell, domain::FaceIndex(face));
+            break;
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  auto result_vector = test_fe->ValueAtFaceQuadrature(test_vector);
+
+  EXPECT_TRUE(bart::test_helpers::CompareVector(expected_vector, result_vector));
 }
 
 

--- a/src/domain/finite_element/tests/finite_element_test.h
+++ b/src/domain/finite_element/tests/finite_element_test.h
@@ -27,6 +27,7 @@ class FiniteElementBaseClassTest : public ::testing::Test {
   void TestSetCell(domain::finite_element::FiniteElement<dim>* test_fe);
   void TestSetCellAndFace(domain::finite_element::FiniteElement<dim>* test_fe);
   void TestValueAtQuadrature(domain::finite_element::FiniteElement<dim>* test_fe);
+  void TestValueAtFaceQuadrature(domain::finite_element::FiniteElement<dim>* test_fe);
   void SetUp() override {
     dealii::GridGenerator::hyper_cube(triangulation_, -1, 1);
     triangulation_.refine_global(2);
@@ -105,9 +106,32 @@ void FiniteElementBaseClassTest<dim>::TestValueAtQuadrature(
   std::vector<double> moment_values(n_dofs, 0.5);
   system::moments::MomentVector test_moment(moment_values.begin(), moment_values.end());
 
-  std::vector<double> expected_vector(test_fe->dofs_per_cell(), 0.5);
+  std::vector<double> expected_vector(test_fe->n_cell_quad_pts(), 0.5);
 
   auto result_vector = test_fe->ValueAtQuadrature(test_moment);
+
+  EXPECT_TRUE(bart::test_helpers::CompareVector(expected_vector, result_vector));
+}
+
+template <int dim>
+void FiniteElementBaseClassTest<dim>::TestValueAtFaceQuadrature(
+    FiniteElement<dim> *test_fe) {
+
+  dof_handler_.distribute_dofs(*test_fe->finite_element());
+
+  auto cell = dof_handler_.begin_active();
+
+  EXPECT_NO_THROW(test_fe->SetFace(cell, domain::FaceIndex(0)));
+
+  int n_dofs = dof_handler_.n_dofs();
+
+  system::MPIVector test_vector(MPI_COMM_WORLD, n_dofs, n_dofs);
+  test_vector = 0.5;
+  test_vector.compress(dealii::VectorOperation::insert);
+
+  std::vector<double> expected_vector(test_fe->n_face_quad_pts(), 0.5);
+
+  auto result_vector = test_fe->ValueAtFaceQuadrature(test_vector);
 
   EXPECT_TRUE(bart::test_helpers::CompareVector(expected_vector, result_vector));
 }

--- a/src/domain/finite_element/tests/finite_element_test.h
+++ b/src/domain/finite_element/tests/finite_element_test.h
@@ -5,6 +5,7 @@
 
 #include "test_helpers/test_assertions.h"
 #include "test_helpers/gmock_wrapper.h"
+#include "test_helpers/dealii_test_domain.h"
 
 namespace bart {
 
@@ -135,6 +136,28 @@ void FiniteElementBaseClassTest<dim>::TestValueAtFaceQuadrature(
 
   EXPECT_TRUE(bart::test_helpers::CompareVector(expected_vector, result_vector));
 }
+
+template <int dim>
+class DomainFiniteElementBaseDomainTest :
+    public ::testing::Test,
+    public bart::testing::DealiiTestDomain<dim> {
+ public:
+  void SetUp() override;
+  void TestValueAtFaceQuadrature(FiniteElement<dim> *test_fe);
+};
+
+template <int dim>
+void DomainFiniteElementBaseDomainTest<dim>::SetUp() {
+  this->SetUpDealii();
+}
+
+template <int dim>
+void DomainFiniteElementBaseDomainTest<dim>::TestValueAtFaceQuadrature(
+    FiniteElement<dim> *test_fe) {
+  EXPECT_TRUE(false);
+}
+
+
 
 } // namespace testing
 

--- a/src/domain/finite_element/tests/finite_element_test.h
+++ b/src/domain/finite_element/tests/finite_element_test.h
@@ -124,15 +124,11 @@ void FiniteElementBaseClassTest<dim>::TestValueAtFaceQuadrature(
 
   EXPECT_NO_THROW(test_fe->SetFace(cell, domain::FaceIndex(0)));
 
-  int n_dofs = dof_handler_.n_dofs();
-
-  system::MPIVector test_vector(MPI_COMM_WORLD, n_dofs, n_dofs);
-  test_vector = 0.5;
-  test_vector.compress(dealii::VectorOperation::insert);
-
+  dealii::Vector<double> values_at_dofs(dof_handler_.n_dofs());
+  values_at_dofs = 0.5;
   std::vector<double> expected_vector(test_fe->n_face_quad_pts(), 0.5);
 
-  auto result_vector = test_fe->ValueAtFaceQuadrature(test_vector);
+  auto result_vector = test_fe->ValueAtFaceQuadrature(values_at_dofs);
 
   EXPECT_TRUE(bart::test_helpers::CompareVector(expected_vector, result_vector));
 }

--- a/src/formulation/angular/self_adjoint_angular_flux.cc
+++ b/src/formulation/angular/self_adjoint_angular_flux.cc
@@ -133,7 +133,7 @@ void SelfAdjointAngularFlux<dim>::FillReflectiveBoundaryLinearTerm(
       for (int i = 0; i < cell_degrees_of_freedom_; ++i) {
         to_fill(i) += normal_dot_omega
             * finite_element_ptr_->FaceShapeValue(i, f_q)
-            * incoming_angular_flux.at(i)
+            * incoming_angular_flux.at(f_q)
             * jacobian;
       }
     }

--- a/src/formulation/angular/self_adjoint_angular_flux.cc
+++ b/src/formulation/angular/self_adjoint_angular_flux.cc
@@ -125,13 +125,13 @@ void SelfAdjointAngularFlux<dim>::FillReflectiveBoundaryLinearTerm(
 
   const double normal_dot_omega = normal_vector * omega;
 
-  if (normal_dot_omega > 0) {
+  if (normal_dot_omega < 0) {
     const auto incoming_angular_flux = finite_element_ptr_->ValueAtFaceQuadrature(
         incoming_flux);
     for (int f_q = 0; f_q < face_quadrature_points_; ++f_q) {
       const double jacobian = finite_element_ptr_->FaceJacobian(f_q);
       for (int i = 0; i < cell_degrees_of_freedom_; ++i) {
-        to_fill(i) += normal_dot_omega
+        to_fill(i) -= normal_dot_omega
             * finite_element_ptr_->FaceShapeValue(i, f_q)
             * incoming_angular_flux.at(f_q)
             * jacobian;

--- a/src/formulation/angular/self_adjoint_angular_flux.cc
+++ b/src/formulation/angular/self_adjoint_angular_flux.cc
@@ -108,6 +108,39 @@ void SelfAdjointAngularFlux<dim>::FillBoundaryBilinearTerm(
 }
 
 template<int dim>
+void SelfAdjointAngularFlux<dim>::FillReflectiveBoundaryLinearTerm(
+    Vector& to_fill,
+    const domain::CellPtr<dim>& cell_ptr,
+    domain::FaceIndex face_number,
+    const std::shared_ptr<quadrature::QuadraturePointI<dim>> quadrature_point,
+    const system::MPIVector& incoming_flux) {
+  VerifyInitialized(__FUNCTION__);
+  ValidateVectorSize(to_fill, __FUNCTION__);
+  AssertThrow(cell_ptr.state() == dealii::IteratorState::valid,
+              dealii::ExcMessage("Bad cell given to FillReflectiveBoundaryLinearTerm"))
+  finite_element_ptr_->SetFace(cell_ptr, face_number);
+
+  auto normal_vector = finite_element_ptr_->FaceNormal();
+  auto omega = quadrature_point->cartesian_position_tensor();
+
+  const double normal_dot_omega = normal_vector * omega;
+
+  if (normal_dot_omega > 0) {
+    const auto incoming_angular_flux = finite_element_ptr_->ValueAtFaceQuadrature(
+        incoming_flux);
+    for (int f_q = 0; f_q < face_quadrature_points_; ++f_q) {
+      const double jacobian = finite_element_ptr_->FaceJacobian(f_q);
+      for (int i = 0; i < cell_degrees_of_freedom_; ++i) {
+        to_fill(i) += normal_dot_omega
+            * finite_element_ptr_->FaceShapeValue(i, f_q)
+            * incoming_angular_flux.at(i)
+            * jacobian;
+      }
+    }
+  }
+}
+
+template<int dim>
 void SelfAdjointAngularFlux<dim>::FillCellCollisionTerm(
     FullMatrix &to_fill,
     const domain::CellPtr<dim> &cell_ptr,

--- a/src/formulation/angular/self_adjoint_angular_flux.cc
+++ b/src/formulation/angular/self_adjoint_angular_flux.cc
@@ -113,7 +113,7 @@ void SelfAdjointAngularFlux<dim>::FillReflectiveBoundaryLinearTerm(
     const domain::CellPtr<dim>& cell_ptr,
     domain::FaceIndex face_number,
     const std::shared_ptr<quadrature::QuadraturePointI<dim>> quadrature_point,
-    const system::MPIVector& incoming_flux) {
+    const dealii::Vector<double>& incoming_flux) {
   VerifyInitialized(__FUNCTION__);
   ValidateVectorSize(to_fill, __FUNCTION__);
   AssertThrow(cell_ptr.state() == dealii::IteratorState::valid,

--- a/src/formulation/angular/self_adjoint_angular_flux.h
+++ b/src/formulation/angular/self_adjoint_angular_flux.h
@@ -34,6 +34,13 @@ class SelfAdjointAngularFlux : public SelfAdjointAngularFluxI<dim> {
       const std::shared_ptr<quadrature::QuadraturePointI<dim>> quadrature_point,
       const system::EnergyGroup group_number) override;
 
+  void FillReflectiveBoundaryLinearTerm(
+      Vector &to_fill,
+      const domain::CellPtr<dim> &cell_ptr,
+      domain::FaceIndex face_number,
+      const std::shared_ptr<quadrature::QuadraturePointI<dim>> quadrature_point,
+      const system::MPIVector& incoming_flux) override;
+
   void FillCellCollisionTerm(
       FullMatrix &to_fill,
       const domain::CellPtr<dim> &cell_ptr,

--- a/src/formulation/angular/self_adjoint_angular_flux.h
+++ b/src/formulation/angular/self_adjoint_angular_flux.h
@@ -39,7 +39,7 @@ class SelfAdjointAngularFlux : public SelfAdjointAngularFluxI<dim> {
       const domain::CellPtr<dim> &cell_ptr,
       domain::FaceIndex face_number,
       const std::shared_ptr<quadrature::QuadraturePointI<dim>> quadrature_point,
-      const system::MPIVector& incoming_flux) override;
+      const dealii::Vector<double>& incoming_flux) override;
 
   void FillCellCollisionTerm(
       FullMatrix &to_fill,

--- a/src/formulation/angular/self_adjoint_angular_flux_i.h
+++ b/src/formulation/angular/self_adjoint_angular_flux_i.h
@@ -57,7 +57,7 @@ class SelfAdjointAngularFluxI {
        const domain::CellPtr<dim>& cell_ptr,
        const domain::FaceIndex face_number,
        const std::shared_ptr<quadrature::QuadraturePointI<dim>> quadrature_point,
-       const system::MPIVector& incoming_flux) = 0;
+       const dealii::Vector<double>& incoming_flux) = 0;
 
   /*!
    * \brief Integrates the bilinear collision term and fills a given matrix.

--- a/src/formulation/angular/self_adjoint_angular_flux_i.h
+++ b/src/formulation/angular/self_adjoint_angular_flux_i.h
@@ -49,6 +49,16 @@ class SelfAdjointAngularFluxI {
       const std::shared_ptr<quadrature::QuadraturePointI<dim>> quadrature_point,
       const system::EnergyGroup group_number) = 0;
 
+  /*! \brief Fills the linear boundary term for reflective boundary conditions.
+   *
+   */
+   virtual void FillReflectiveBoundaryLinearTerm(
+       Vector& to_fill,
+       const domain::CellPtr<dim>& cell_ptr,
+       const domain::FaceIndex face_number,
+       const std::shared_ptr<quadrature::QuadraturePointI<dim>> quadrature_point,
+       const system::MPIVector& incoming_flux) = 0;
+
   /*!
    * \brief Integrates the bilinear collision term and fills a given matrix.
    *

--- a/src/formulation/angular/tests/self_adjoint_angular_flux_mock.h
+++ b/src/formulation/angular/tests/self_adjoint_angular_flux_mock.h
@@ -20,6 +20,11 @@ class SelfAdjointAngularFluxMock :
       const domain::FaceIndex,
       const std::shared_ptr<quadrature::QuadraturePointI<dim>> quadrature_point,
       const system::EnergyGroup group_number), (override));
+  MOCK_METHOD(void, FillReflectiveBoundaryLinearTerm, (Vector&,
+      const domain::CellPtr<dim>&,
+      const domain::FaceIndex,
+      const std::shared_ptr<quadrature::QuadraturePointI<dim>>,
+      const system::MPIVector&), (override));
   MOCK_METHOD(void, FillCellCollisionTerm, (FullMatrix&,
       const domain::CellPtr<dim>&,
       const system::EnergyGroup), (override));

--- a/src/formulation/angular/tests/self_adjoint_angular_flux_mock.h
+++ b/src/formulation/angular/tests/self_adjoint_angular_flux_mock.h
@@ -24,7 +24,7 @@ class SelfAdjointAngularFluxMock :
       const domain::CellPtr<dim>&,
       const domain::FaceIndex,
       const std::shared_ptr<quadrature::QuadraturePointI<dim>>,
-      const system::MPIVector&), (override));
+      const dealii::Vector<double>&), (override));
   MOCK_METHOD(void, FillCellCollisionTerm, (FullMatrix&,
       const domain::CellPtr<dim>&,
       const system::EnergyGroup), (override));

--- a/src/formulation/angular/tests/self_adjoint_angular_flux_test.cc
+++ b/src/formulation/angular/tests/self_adjoint_angular_flux_test.cc
@@ -638,7 +638,7 @@ TYPED_TEST(FormulationAngularSelfAdjointAngularFluxTest,
 }
 
 TYPED_TEST(FormulationAngularSelfAdjointAngularFluxTest,
-    FillReflectiveBoundaryLinearTermTestLessThanZero) {
+    FillReflectiveBoundaryLinearTermTestGreaterThanZero) {
   constexpr int dim = this->dim;
 
   formulation::angular::SelfAdjointAngularFlux<dim> test_saaf(
@@ -657,8 +657,7 @@ TYPED_TEST(FormulationAngularSelfAdjointAngularFluxTest,
   int face_index = 0;
 
   dealii::Tensor<1, dim> normal;
-  for (int i = 0; i < dim; ++i)
-    normal[i] = -1;
+
   EXPECT_CALL(*this->mock_finite_element_ptr_, SetFace(this->cell_ptr_,
                                                        domain::FaceIndex(face_index)));
   EXPECT_CALL(*this->mock_finite_element_ptr_, FaceNormal())
@@ -695,7 +694,7 @@ TYPED_TEST(FormulationAngularSelfAdjointAngularFluxTest,
 
   dealii::Tensor<1, dim> normal;
   for (int i = 0; i < dim; ++i)
-    normal[i] = 1;
+    normal[i] = -1;
   EXPECT_CALL(*this->mock_finite_element_ptr_, SetFace(this->cell_ptr_,
                                                        domain::FaceIndex(face_index)));
   EXPECT_CALL(*this->mock_finite_element_ptr_, FaceNormal())

--- a/src/formulation/angular/tests/self_adjoint_angular_flux_test.cc
+++ b/src/formulation/angular/tests/self_adjoint_angular_flux_test.cc
@@ -189,8 +189,7 @@ void FormulationAngularSelfAdjointAngularFluxTest<DimensionWrapper>::SetUp() {
   ON_CALL(*mock_finite_element_ptr_,
       ValueAtQuadrature(group_1_moment_))
       .WillByDefault(Return(group_1_moment_values_));
-  ON_CALL(*mock_finite_element_ptr_,
-      ValueAtFaceQuadrature(A<const bart::system::MPIVector&>()))
+  ON_CALL(*mock_finite_element_ptr_, ValueAtFaceQuadrature(_))
       .WillByDefault(Return(group_0_moment_values_));
 
 
@@ -611,7 +610,7 @@ TYPED_TEST(FormulationAngularSelfAdjointAngularFluxTest,
         invalid_cell_ptr,
         domain::FaceIndex(0),
         angle_ptr,
-        system::MPIVector{});
+        dealii::Vector<double>{});
                    });
 }
 
@@ -633,7 +632,7 @@ TYPED_TEST(FormulationAngularSelfAdjointAngularFluxTest,
                                                       this->cell_ptr_,
                                                       domain::FaceIndex(0),
                                                       angle_ptr,
-                                                      system::MPIVector{});
+                                                      dealii::Vector<double>{});
                    });
 }
 
@@ -668,7 +667,7 @@ TYPED_TEST(FormulationAngularSelfAdjointAngularFluxTest,
                                                      this->cell_ptr_,
                                                      domain::FaceIndex(0),
                                                      angle_ptr,
-                                                     system::MPIVector{});
+                                                     dealii::Vector<double>{});
                   });
 
   EXPECT_EQ(expected_results, cell_vector);
@@ -710,8 +709,7 @@ TYPED_TEST(FormulationAngularSelfAdjointAngularFluxTest,
   }
 
 
-  EXPECT_CALL(*this->mock_finite_element_ptr_,
-      ValueAtFaceQuadrature(A<const bart::system::MPIVector&>()))
+  EXPECT_CALL(*this->mock_finite_element_ptr_, ValueAtFaceQuadrature(_))
       .WillOnce(DoDefault());
 
   EXPECT_NO_THROW({
@@ -719,7 +717,7 @@ TYPED_TEST(FormulationAngularSelfAdjointAngularFluxTest,
                                                      this->cell_ptr_,
                                                      domain::FaceIndex(0),
                                                      angle_ptr,
-                                                     system::MPIVector{});
+                                                     dealii::Vector<double>{});
                   });
 
   EXPECT_EQ(expected_results, cell_vector);

--- a/src/formulation/updater/boundary_conditions_updater_i.h
+++ b/src/formulation/updater/boundary_conditions_updater_i.h
@@ -1,0 +1,29 @@
+#ifndef BART_SRC_FORMULATION_UPDATER_BOUNDARY_CONDITIONS_UPDATER_I_H_
+#define BART_SRC_FORMULATION_UPDATER_BOUNDARY_CONDITIONS_UPDATER_I_H_
+
+#include "system/system.h"
+#include "system/system_types.h"
+#include "quadrature/quadrature_types.h"
+
+namespace bart {
+
+namespace formulation {
+
+namespace updater {
+
+class BoundaryConditionsUpdaterI {
+ public:
+  virtual ~BoundaryConditionsUpdaterI() = default;
+  virtual void UpdateBoundaryConditions(system::System& to_update,
+                                        system::EnergyGroup,
+                                        quadrature::QuadraturePointIndex) = 0;
+};
+
+
+} // namespace updater
+
+} // namespace formulation
+
+} // namespace bart
+
+#endif //BART_SRC_FORMULATION_UPDATER_BOUNDARY_CONDITIONS_UPDATER_I_H_

--- a/src/formulation/updater/saaf_updater.cc
+++ b/src/formulation/updater/saaf_updater.cc
@@ -36,14 +36,6 @@ SAAFUpdater<dim>::SAAFUpdater(
                   quadrature_set_ptr) {
   reflective_boundaries_ = reflective_boundaries;
   angular_solution_ptr_map_ = angular_solution_ptr_map;
-  const int total_angles = quadrature_set_ptr_->size();
-  for (auto& [energy_group, solution_ptr] : angular_solution_ptr_map_) {
-    AssertThrow(total_angles == solution_ptr->total_angles(),
-                dealii::ExcMessage("Error in construction of SAAF Updater, "
-                                   "total angles in quadrature set does not "
-                                   "match size of one or more angular "
-                                   "solutions"));
-  }
 }
 
 template<int dim>
@@ -63,8 +55,8 @@ void SAAFUpdater<dim>::UpdateBoundaryConditions(
       dealii::ExcMessage("Error in UpdateBoundaryConditions, passed "
                          "quadrature point has no reflection"))
 
-  const auto &incoming_flux = angular_solution_ptr_map_.at(group)->GetSolution(
-      reflected_quadrature_point_index.value());
+  const auto incoming_flux = angular_solution_ptr_map_.at(
+      system::SolutionIndex(group, reflected_quadrature_point_index.value()));
   auto reflective_boundary_term_function =
       [&](formulation::Vector &cell_vector,
           const domain::FaceIndex face_index,
@@ -75,7 +67,7 @@ void SAAFUpdater<dim>::UpdateBoundaryConditions(
           cell_ptr,
           face_index,
           quadrature_point_ptr,
-          incoming_flux);
+          *incoming_flux);
     }
   };
   *boundary_vector_ptr = 0;

--- a/src/formulation/updater/saaf_updater.cc
+++ b/src/formulation/updater/saaf_updater.cc
@@ -30,10 +30,20 @@ SAAFUpdater<dim>::SAAFUpdater(
     std::unique_ptr<SAAFFormulationType> formulation_ptr,
     std::unique_ptr<StamperType> stamper_ptr,
     const std::shared_ptr<QuadratureSetType>& quadrature_set_ptr,
+    const EnergyGroupToAngularSolutionPtrMap& angular_solution_ptr_map,
     const std::unordered_set<Boundary> reflective_boundaries)
     : SAAFUpdater(std::move(formulation_ptr), std::move(stamper_ptr),
                   quadrature_set_ptr) {
   reflective_boundaries_ = reflective_boundaries;
+  angular_solution_ptr_map_ = angular_solution_ptr_map;
+  for (const int total_angles = quadrature_set_ptr_->size();
+       auto& [energy_group, solution_ptr] : angular_solution_ptr_map_) {
+    AssertThrow(total_angles == solution_ptr->total_angles(),
+                dealii::ExcMessage("Error in construction of SAAF Updater, "
+                                   "total angles in quadrature set does not "
+                                   "match size of one or more angular "
+                                   "solutions"));
+  }
 }
 
 template<int dim>

--- a/src/formulation/updater/saaf_updater.cc
+++ b/src/formulation/updater/saaf_updater.cc
@@ -57,22 +57,24 @@ void SAAFUpdater<dim>::UpdateBoundaryConditions(
 
   const auto incoming_flux = angular_solution_ptr_map_.at(
       system::SolutionIndex(group, reflected_quadrature_point_index.value()));
-  auto reflective_boundary_term_function =
-      [&](formulation::Vector &cell_vector,
-          const domain::FaceIndex face_index,
-          const domain::CellPtr<dim>& cell_ptr) -> void {
-    if (IsOnReflectiveBoundary(cell_ptr, face_index)) {
-      formulation_ptr_->FillReflectiveBoundaryLinearTerm(
-          cell_vector,
-          cell_ptr,
-          face_index,
-          quadrature_point_ptr,
-          *incoming_flux);
-    }
-  };
-  *boundary_vector_ptr = 0;
-  stamper_ptr_->StampBoundaryVector(*boundary_vector_ptr,
-                                    reflective_boundary_term_function);
+  if (incoming_flux->size() > 0) {
+    auto reflective_boundary_term_function =
+        [&](formulation::Vector &cell_vector,
+            const domain::FaceIndex face_index,
+            const domain::CellPtr <dim> &cell_ptr) -> void {
+          if (IsOnReflectiveBoundary(cell_ptr, face_index)) {
+            formulation_ptr_->FillReflectiveBoundaryLinearTerm(
+                cell_vector,
+                cell_ptr,
+                face_index,
+                quadrature_point_ptr,
+                *incoming_flux);
+          }
+        };
+    *boundary_vector_ptr = 0;
+    stamper_ptr_->StampBoundaryVector(*boundary_vector_ptr,
+                                      reflective_boundary_term_function);
+  }
 }
 
 template<int dim>

--- a/src/formulation/updater/saaf_updater.cc
+++ b/src/formulation/updater/saaf_updater.cc
@@ -24,6 +24,18 @@ SAAFUpdater<dim>::SAAFUpdater(
               dealii::ExcMessage("Error in constructor of SAAFUpdater, "
                                  "quadrature set pointer passed is null"))
 }
+
+template<int dim>
+SAAFUpdater<dim>::SAAFUpdater(
+    std::unique_ptr<SAAFFormulationType> formulation_ptr,
+    std::unique_ptr<StamperType> stamper_ptr,
+    const std::shared_ptr<QuadratureSetType>& quadrature_set_ptr,
+    const std::unordered_set<Boundary> reflective_boundaries)
+    : SAAFUpdater(std::move(formulation_ptr), std::move(stamper_ptr),
+                  quadrature_set_ptr) {
+  reflective_boundaries_ = reflective_boundaries;
+}
+
 template<int dim>
 void SAAFUpdater<dim>::UpdateFixedTerms(
     system::System &to_update,

--- a/src/formulation/updater/saaf_updater.cc
+++ b/src/formulation/updater/saaf_updater.cc
@@ -47,6 +47,14 @@ SAAFUpdater<dim>::SAAFUpdater(
 }
 
 template<int dim>
+void SAAFUpdater<dim>::UpdateBoundaryConditions(
+    system::System &to_update,
+    system::EnergyGroup group,
+    quadrature::QuadraturePointIndex index) {
+
+}
+
+template<int dim>
 void SAAFUpdater<dim>::UpdateFixedTerms(
     system::System &to_update,
     system::EnergyGroup group,

--- a/src/formulation/updater/saaf_updater.cc
+++ b/src/formulation/updater/saaf_updater.cc
@@ -36,8 +36,8 @@ SAAFUpdater<dim>::SAAFUpdater(
                   quadrature_set_ptr) {
   reflective_boundaries_ = reflective_boundaries;
   angular_solution_ptr_map_ = angular_solution_ptr_map;
-  for (const int total_angles = quadrature_set_ptr_->size();
-       auto& [energy_group, solution_ptr] : angular_solution_ptr_map_) {
+  const int total_angles = quadrature_set_ptr_->size();
+  for (auto& [energy_group, solution_ptr] : angular_solution_ptr_map_) {
     AssertThrow(total_angles == solution_ptr->total_angles(),
                 dealii::ExcMessage("Error in construction of SAAF Updater, "
                                    "total angles in quadrature set does not "

--- a/src/formulation/updater/saaf_updater.h
+++ b/src/formulation/updater/saaf_updater.h
@@ -64,6 +64,12 @@ class SAAFUpdater :
   QuadratureSetType* quadrature_set_ptr() const {
     return quadrature_set_ptr_.get();};
  private:
+  bool IsOnReflectiveBoundary(const domain::CellPtr<dim>& cell_ptr,
+                              const domain::FaceIndex face_index) const {
+    return reflective_boundaries_.count(
+        static_cast<const Boundary>(
+            cell_ptr->face(face_index.get())->boundary_id()));
+  }
   std::unique_ptr<SAAFFormulationType> formulation_ptr_;
   std::unique_ptr<StamperType> stamper_ptr_;
   std::shared_ptr<QuadratureSetType> quadrature_set_ptr_;

--- a/src/formulation/updater/saaf_updater.h
+++ b/src/formulation/updater/saaf_updater.h
@@ -11,6 +11,7 @@
 #include "formulation/updater/fission_source_updater_i.h"
 #include "quadrature/quadrature_set_i.h"
 #include "problem/parameter_types.h"
+#include "system/solution/solution_types.h"
 
 namespace bart {
 
@@ -25,6 +26,7 @@ class SAAFUpdater :
     public FissionSourceUpdaterI {
  public:
   using Boundary = problem::Boundary;
+  using EnergyGroupToAngularSolutionPtrMap = system::solution::EnergyGroupToAngularSolutionPtrMap;
   using SAAFFormulationType = formulation::angular::SelfAdjointAngularFluxI<dim>;
   using StamperType = formulation::StamperI<dim>;
   using QuadratureSetType = quadrature::QuadratureSetI<dim>;
@@ -35,6 +37,7 @@ class SAAFUpdater :
   SAAFUpdater(std::unique_ptr<SAAFFormulationType>,
               std::unique_ptr<StamperType>,
               const std::shared_ptr<QuadratureSetType>&,
+              const EnergyGroupToAngularSolutionPtrMap&,
               const std::unordered_set<Boundary>);
 
   void UpdateFixedTerms(system::System &to_update,
@@ -47,6 +50,8 @@ class SAAFUpdater :
                               system::EnergyGroup group,
                               quadrature::QuadraturePointIndex index) override;
 
+  EnergyGroupToAngularSolutionPtrMap angular_solution_ptr_map() const {
+    return angular_solution_ptr_map_; }
   std::unordered_set<Boundary> reflective_boundaries() const {
     return reflective_boundaries_; }
   SAAFFormulationType* formulation_ptr() const {return formulation_ptr_.get();};
@@ -57,6 +62,7 @@ class SAAFUpdater :
   std::unique_ptr<SAAFFormulationType> formulation_ptr_;
   std::unique_ptr<StamperType> stamper_ptr_;
   std::shared_ptr<QuadratureSetType> quadrature_set_ptr_;
+  EnergyGroupToAngularSolutionPtrMap angular_solution_ptr_map_;
   std::unordered_set<Boundary> reflective_boundaries_ = {};
 };
 

--- a/src/formulation/updater/saaf_updater.h
+++ b/src/formulation/updater/saaf_updater.h
@@ -2,6 +2,7 @@
 #define BART_SRC_FORMULATION_UPDATER_TESTS_SAAF_UPDATER_H_
 
 #include <memory>
+#include <unordered_set>
 
 #include "formulation/angular/self_adjoint_angular_flux_i.h"
 #include "formulation/stamper_i.h"
@@ -9,6 +10,7 @@
 #include "formulation/updater/scattering_source_updater_i.h"
 #include "formulation/updater/fission_source_updater_i.h"
 #include "quadrature/quadrature_set_i.h"
+#include "problem/parameter_types.h"
 
 namespace bart {
 
@@ -22,12 +24,18 @@ class SAAFUpdater :
     public ScatteringSourceUpdaterI,
     public FissionSourceUpdaterI {
  public:
+  using Boundary = problem::Boundary;
   using SAAFFormulationType = formulation::angular::SelfAdjointAngularFluxI<dim>;
   using StamperType = formulation::StamperI<dim>;
   using QuadratureSetType = quadrature::QuadratureSetI<dim>;
+
   SAAFUpdater(std::unique_ptr<SAAFFormulationType>,
               std::unique_ptr<StamperType>,
               const std::shared_ptr<QuadratureSetType>&);
+  SAAFUpdater(std::unique_ptr<SAAFFormulationType>,
+              std::unique_ptr<StamperType>,
+              const std::shared_ptr<QuadratureSetType>&,
+              const std::unordered_set<Boundary>);
 
   void UpdateFixedTerms(system::System &to_update,
                         system::EnergyGroup group,
@@ -39,6 +47,8 @@ class SAAFUpdater :
                               system::EnergyGroup group,
                               quadrature::QuadraturePointIndex index) override;
 
+  std::unordered_set<Boundary> reflective_boundaries() const {
+    return reflective_boundaries_; }
   SAAFFormulationType* formulation_ptr() const {return formulation_ptr_.get();};
   StamperType* stamper_ptr() const {return stamper_ptr_.get();};
   QuadratureSetType* quadrature_set_ptr() const {
@@ -47,6 +57,7 @@ class SAAFUpdater :
   std::unique_ptr<SAAFFormulationType> formulation_ptr_;
   std::unique_ptr<StamperType> stamper_ptr_;
   std::shared_ptr<QuadratureSetType> quadrature_set_ptr_;
+  std::unordered_set<Boundary> reflective_boundaries_ = {};
 };
 
 } // namespace updater

--- a/src/formulation/updater/saaf_updater.h
+++ b/src/formulation/updater/saaf_updater.h
@@ -7,6 +7,7 @@
 #include "formulation/angular/self_adjoint_angular_flux_i.h"
 #include "formulation/stamper_i.h"
 #include "formulation/updater/fixed_updater_i.h"
+#include "formulation/updater/boundary_conditions_updater_i.h"
 #include "formulation/updater/scattering_source_updater_i.h"
 #include "formulation/updater/fission_source_updater_i.h"
 #include "quadrature/quadrature_set_i.h"
@@ -22,6 +23,7 @@ namespace updater {
 template <int dim>
 class SAAFUpdater :
     public FixedUpdaterI,
+    public BoundaryConditionsUpdaterI,
     public ScatteringSourceUpdaterI,
     public FissionSourceUpdaterI {
  public:
@@ -40,6 +42,9 @@ class SAAFUpdater :
               const EnergyGroupToAngularSolutionPtrMap&,
               const std::unordered_set<Boundary>);
 
+  void UpdateBoundaryConditions(system::System &to_update,
+                                system::EnergyGroup group,
+                                quadrature::QuadraturePointIndex index) override;
   void UpdateFixedTerms(system::System &to_update,
                         system::EnergyGroup group,
                         quadrature::QuadraturePointIndex index) override;

--- a/src/formulation/updater/tests/boundary_conditions_updater_mock.h
+++ b/src/formulation/updater/tests/boundary_conditions_updater_mock.h
@@ -13,8 +13,8 @@ namespace updater {
 class BoundaryConditionsUpdaterMock : public BoundaryConditionsUpdaterI {
  public:
   MOCK_METHOD(void, UpdateBoundaryConditions,
-      (system::SystemWithAngularSolution&, system::EnergyGroup,
-          quadrature::QuadraturePointIndex), (override));
+      (system::System&, system::EnergyGroup, quadrature::QuadraturePointIndex),
+      (override));
 };
 
 } // namespace updater

--- a/src/formulation/updater/tests/saaf_updater_test.cc
+++ b/src/formulation/updater/tests/saaf_updater_test.cc
@@ -276,6 +276,40 @@ TYPED_TEST(FormulationUpdaterSAAFTest, UpdateBoundaryConditionsTest) {
                                               *this->vector_to_stamp));
 }
 
+TYPED_TEST(FormulationUpdaterSAAFTest, UpdateBoundaryConditionsNoReflectionTest) {
+  constexpr int dim = this->dim;
+  using QuadraturePointType = quadrature::QuadraturePointI<dim>;
+  using VariableLinearTerms = system::terms::VariableLinearTerms;
+  using MockSolutionType = system::solution::MPIGroupAngularSolutionMock;
+
+  system::EnergyGroup group_number(this->group_number);
+
+  // Quadrature point and reflection
+  quadrature::QuadraturePointIndex quad_index(this->angle_index),
+      reflected_index(this->reflected_angle_index);
+  std::shared_ptr<QuadraturePointType> quadrature_point_ptr_,
+      reflected_point_ptr_;
+
+  // Mock expectation layout
+  // -- Retrieve the correct variable term to update, returns vector_to_stamp
+  EXPECT_CALL(*this->mock_rhs_obs_ptr_, GetVariableTermPtr(
+      this->index, VariableLinearTerms::kReflectiveBoundaryCondition))
+      .WillOnce(DoDefault());
+  // -- Get the quadrature point identified by the passed index
+  EXPECT_CALL(*this->quadrature_set_ptr_, GetQuadraturePoint(quad_index))
+      .WillOnce(Return(quadrature_point_ptr_));
+  // -- Get the quadrature point's reflection for angular flux
+  EXPECT_CALL(*this->quadrature_set_ptr_,
+              GetReflectionIndex(quadrature_point_ptr_))
+      .WillOnce(Return(std::nullopt));
+  EXPECT_ANY_THROW({
+    this->test_updater_ptr->UpdateBoundaryConditions(this->test_system_,
+                                                     group_number,
+                                                     quad_index);
+                   }
+  );
+}
+
 // ===== Update Fixed Terms Tests ==============================================
 
 TYPED_TEST(FormulationUpdaterSAAFTest, UpdateFixedTermsTest) {

--- a/src/formulation/updater/tests/saaf_updater_test.cc
+++ b/src/formulation/updater/tests/saaf_updater_test.cc
@@ -6,13 +6,16 @@
 #include "formulation/updater/tests/updater_tests.h"
 #include "test_helpers/gmock_wrapper.h"
 #include "test_helpers/test_assertions.h"
+#include "system/solution/solution_types.h"
+#include "system/solution/tests/mpi_group_angular_solution_mock.h"
 
 namespace {
 
 using namespace bart;
 
 using ::testing::Return, ::testing::Ref, ::testing::Invoke, ::testing::_,
-::testing::A, ::testing::WithArg, ::testing::DoDefault, ::testing::ReturnRef;
+::testing::A, ::testing::WithArg, ::testing::DoDefault, ::testing::ReturnRef,
+::testing::NiceMock;
 
 template <typename DimensionWrapper>
 class FormulationUpdaterSAAFTest :
@@ -20,10 +23,11 @@ class FormulationUpdaterSAAFTest :
  public:
   static constexpr int dim = DimensionWrapper::value;
 
+  using AngularSolutionType = NiceMock<system::solution::MPIGroupAngularSolutionMock>;
   using FormulationType = formulation::angular::SelfAdjointAngularFluxMock<dim>;
   using StamperType = formulation::StamperMock<dim>;
   using UpdaterType = formulation::updater::SAAFUpdater<dim>;
-  using QuadratureSetType = quadrature::QuadratureSetMock<dim>;
+  using QuadratureSetType = NiceMock<quadrature::QuadratureSetMock<dim>>;
   using Boundary = problem::Boundary;
 
   // Test object
@@ -37,7 +41,7 @@ class FormulationUpdaterSAAFTest :
   std::unordered_set<Boundary> reflective_boundaries{Boundary::kXMin,
                                                      Boundary::kYMax,
                                                      Boundary::kZMin};
-
+  system::solution::EnergyGroupToAngularSolutionPtrMap angular_solution_ptr_map_;
   void SetUp() override;
 };
 
@@ -48,11 +52,22 @@ void FormulationUpdaterSAAFTest<DimensionWrapper>::SetUp() {
   formulation_obs_ptr_ = formulation_ptr.get();
   auto stamper_ptr = this->MakeStamper();
   stamper_obs_ptr_ = stamper_ptr.get();
-
   quadrature_set_ptr_ = std::make_shared<QuadratureSetType>();
+
+  auto angular_solution_ptr = std::make_shared<AngularSolutionType>();
+  ON_CALL(*angular_solution_ptr, total_angles())
+      .WillByDefault(Return(this->total_angles));
+
+  angular_solution_ptr_map_.insert({system::EnergyGroup(this->group_number),
+                                    angular_solution_ptr});
+
+  ON_CALL(*quadrature_set_ptr_, size())
+      .WillByDefault(Return(this->total_angles));
+
   test_updater_ptr = std::make_unique<UpdaterType>(std::move(formulation_ptr),
                                                    std::move(stamper_ptr),
                                                    quadrature_set_ptr_,
+                                                   angular_solution_ptr_map_,
                                                    reflective_boundaries);
 }
 
@@ -89,22 +104,78 @@ TYPED_TEST(FormulationUpdaterSAAFTest, ConstructorReflective) {
   using StamperType = formulation::StamperMock<dim>;
   using UpdaterType = formulation::updater::SAAFUpdater<dim>;
   using QuadratureSetType = quadrature::QuadratureSetMock<dim>;
+  using AngularSolutionType = bart::system::solution::MPIGroupAngularSolutionMock;
 
   auto formulation_ptr = std::make_unique<FormulationType>();
   auto stamper_ptr = std::make_unique<StamperType>();
   auto quadrature_set_ptr = std::make_shared<QuadratureSetType>();
   std::unique_ptr<UpdaterType> test_updater_ptr;
+  system::solution::EnergyGroupToAngularSolutionPtrMap angular_solution_ptr_map;
+
+  auto angular_solution_ptr = std::make_shared<AngularSolutionType>();
+
+  EXPECT_CALL(*quadrature_set_ptr, size()).WillOnce(Return(this->total_angles));
+
+  for (int group = 0; group < this->total_groups; ++group) {
+    auto angular_solution_ptr = std::make_shared<AngularSolutionType>();
+    EXPECT_CALL(*angular_solution_ptr, total_angles())
+        .WillOnce(Return(this->total_angles));
+    angular_solution_ptr_map.insert(
+        {bart::system::EnergyGroup(group), angular_solution_ptr});
+  }
 
   EXPECT_NO_THROW({
     test_updater_ptr = std::make_unique<UpdaterType>(std::move(formulation_ptr),
                                                      std::move(stamper_ptr),
                                                      quadrature_set_ptr,
+                                                     angular_solution_ptr_map,
                                                      this->reflective_boundaries);
                   });
   EXPECT_NE(test_updater_ptr->formulation_ptr(), nullptr);
   EXPECT_NE(test_updater_ptr->stamper_ptr(), nullptr);
   EXPECT_NE(test_updater_ptr->quadrature_set_ptr(), nullptr);
+  EXPECT_EQ(test_updater_ptr->angular_solution_ptr_map(),
+            angular_solution_ptr_map);
   EXPECT_EQ(test_updater_ptr->reflective_boundaries(), this->reflective_boundaries);
+}
+
+TYPED_TEST(FormulationUpdaterSAAFTest, ConstructorReflectiveBadAngleMatch) {
+  constexpr int dim = this->dim;
+  using FormulationType = formulation::angular::SelfAdjointAngularFluxMock<dim>;
+  using StamperType = formulation::StamperMock<dim>;
+  using UpdaterType = formulation::updater::SAAFUpdater<dim>;
+  using QuadratureSetType = quadrature::QuadratureSetMock<dim>;
+  using AngularSolutionType = bart::system::solution::MPIGroupAngularSolutionMock;
+
+  auto formulation_ptr = std::make_unique<FormulationType>();
+  auto stamper_ptr = std::make_unique<StamperType>();
+  auto quadrature_set_ptr = std::make_shared<QuadratureSetType>();
+  std::unique_ptr<UpdaterType> test_updater_ptr;
+  system::solution::EnergyGroupToAngularSolutionPtrMap angular_solution_ptr_map;
+
+  EXPECT_CALL(*quadrature_set_ptr, size()).WillOnce(Return(this->total_angles));
+
+  for (int group = 0; group < this->total_groups; ++group) {
+    auto angular_solution_ptr = std::make_shared<AngularSolutionType>();
+    if (group != this->group_number) {
+      EXPECT_CALL(*angular_solution_ptr, total_angles())
+          .Times(::testing::AtMost(1))
+          .WillRepeatedly(Return(this->total_angles));
+    } else {
+      EXPECT_CALL(*angular_solution_ptr, total_angles())
+          .WillOnce(Return(this->total_angles + 1));
+    }
+    angular_solution_ptr_map.insert(
+        {bart::system::EnergyGroup(group), angular_solution_ptr});
+  }
+
+  EXPECT_ANY_THROW({
+    test_updater_ptr = std::make_unique<UpdaterType>(std::move(formulation_ptr),
+                                                     std::move(stamper_ptr),
+                                                     quadrature_set_ptr,
+                                                     angular_solution_ptr_map,
+                                                     this->reflective_boundaries);
+                  });
 }
 
 TYPED_TEST(FormulationUpdaterSAAFTest, ConstructorBadDepdendencies) {

--- a/src/formulation/updater/tests/saaf_updater_test.cc
+++ b/src/formulation/updater/tests/saaf_updater_test.cc
@@ -62,10 +62,10 @@ void FormulationUpdaterSAAFTest<DimensionWrapper>::SetUp() {
 
   angular_solution_ptr_map_.insert({system::SolutionIndex(this->group_number,
                                                           this->angle_index),
-                                    std::make_shared<dealii::Vector<double>>()});
+                                    std::make_shared<dealii::Vector<double>>(4)});
   angular_solution_ptr_map_.insert({system::SolutionIndex(this->group_number,
                                                           this->reflected_angle_index),
-                                    std::make_shared<dealii::Vector<double>>()});
+                                    std::make_shared<dealii::Vector<double>>(4)});
 
   test_updater_ptr = std::make_unique<UpdaterType>(std::move(formulation_ptr),
                                                    std::move(stamper_ptr),

--- a/src/formulation/updater/tests/updater_tests.h
+++ b/src/formulation/updater/tests/updater_tests.h
@@ -35,6 +35,7 @@ class UpdaterTests : public ::testing::Test,
 
   // Test parameters
   const int total_groups = bart::test_helpers::RandomDouble(2, 5);
+  const int total_angles = total_groups + 1;
 
   // Call parameters (objects and parameters used in update calls)
   system::System test_system_;
@@ -98,8 +99,7 @@ std::unique_ptr<StamperMock<dim>> UpdaterTests<dim>::MakeStamper() {
   ON_CALL(*mock_stamper_ptr, StampBoundaryVector(_,_))
       .WillByDefault(WithArg<1>(Invoke(this, &formulation::updater::test_helpers::UpdaterTests<dim>::EvaluateVectorFunctionOnBoundary)));
 
-
-  return std::move(mock_stamper_ptr);
+  return mock_stamper_ptr;
 }
 
 template <int dim>

--- a/src/formulation/updater/tests/updater_tests.h
+++ b/src/formulation/updater/tests/updater_tests.h
@@ -10,6 +10,7 @@
 #include "system/terms/tests/bilinear_term_mock.h"
 #include "system/terms/tests/linear_term_mock.h"
 #include "system/moments/tests/spherical_harmonic_mock.h"
+#include "system/system.h"
 #include "test_helpers/gmock_wrapper.h"
 #include "test_helpers/test_helper_functions.h"
 #include "test_helpers/dealii_test_domain.h"
@@ -32,16 +33,19 @@ class UpdaterTests : public ::testing::Test,
  public:
   using StamperType = formulation::StamperMock<dim>;
   using MomentsType = system::moments::SphericalHarmonicMock;
+  using SystemType = system::System;
 
   // Test parameters
   const int total_groups = bart::test_helpers::RandomDouble(2, 5);
   const int total_angles = total_groups + 1;
 
   // Call parameters (objects and parameters used in update calls)
-  system::System test_system_;
+  SystemType test_system_;
   const int group_number = bart::test_helpers::RandomDouble(0, total_groups);
   const int angle_index = bart::test_helpers::RandomDouble(0, 10);
+  const int reflected_angle_index = bart::test_helpers::RandomDouble(11, 20);
   const system::Index index{group_number, angle_index};
+  const system::Index reflected_index{group_number, reflected_angle_index};
 
   // Mock system object observation pointers
   bart::system::terms::BilinearTermMock* mock_lhs_obs_ptr_;

--- a/src/framework/builder/framework_builder.cc
+++ b/src/framework/builder/framework_builder.cc
@@ -103,6 +103,9 @@ auto FrameworkBuilder<dim>::BuildFramework(std::string name,
   if (need_angular_solution_storage) {
     system::SetUpEnergyGroupToAngularSolutionPtrMap(angular_solutions_,
                                                     n_groups, n_angles);
+    for (auto& solution_pair : angular_solutions_) {
+      system::SetUpMPIAngularSolution(*solution_pair.second, *domain_ptr);
+    }
   }
 
 

--- a/src/framework/builder/framework_builder.cc
+++ b/src/framework/builder/framework_builder.cc
@@ -103,9 +103,6 @@ auto FrameworkBuilder<dim>::BuildFramework(std::string name,
   if (need_angular_solution_storage) {
     system::SetUpEnergyGroupToAngularSolutionPtrMap(angular_solutions_,
                                                     n_groups, n_angles);
-    for (auto& solution_pair : angular_solutions_) {
-      system::SetUpMPIAngularSolution(*solution_pair.second, *domain_ptr);
-    }
   }
 
 

--- a/src/framework/builder/framework_builder.cc
+++ b/src/framework/builder/framework_builder.cc
@@ -174,7 +174,9 @@ auto FrameworkBuilder<dim>::BuildFramework(std::string name,
       convergence_reporter_ptr);
 
   auto system_ptr = BuildSystem(n_groups, n_angles, *domain_ptr,
-                                group_solution_ptr->solutions().at(0).size());
+                                group_solution_ptr->solutions().at(0).size(),
+                                prm.IsEigenvalueProblem(),
+                                need_angular_solution_storage);
 
   auto results_output_ptr =
       std::make_unique<results::OutputDealiiVtu<dim>>(domain_ptr);
@@ -642,14 +644,15 @@ auto FrameworkBuilder<dim>::BuildSystem(
     const int total_angles,
     const DomainType& domain,
     const std::size_t solution_size,
-    bool is_eigenvalue_problem) -> std::unique_ptr<SystemType> {
+    bool is_eigenvalue_problem,
+    bool need_rhs_boundary_condition) -> std::unique_ptr<SystemType> {
   std::unique_ptr<SystemType> return_ptr;
 
   ReportBuildingComponant("system");
   try {
     return_ptr = std::move(std::make_unique<SystemType>());
     system::InitializeSystem(*return_ptr, total_groups, total_angles,
-                             is_eigenvalue_problem);
+                             is_eigenvalue_problem, need_rhs_boundary_condition);
     system::SetUpSystemTerms(*return_ptr, domain);
     system::SetUpSystemMoments(*return_ptr, solution_size);
     ReportBuildSuccess("system");

--- a/src/framework/builder/framework_builder.h
+++ b/src/framework/builder/framework_builder.h
@@ -125,7 +125,7 @@ class FrameworkBuilder {
       std::unique_ptr<MomentConvergenceCheckerType>,
       std::unique_ptr<MomentCalculatorType>,
       const std::shared_ptr<GroupSolutionType>&,
-      const std::shared_ptr<ScatteringSourceUpdaterType>&,
+      const UpdaterPointers& updater_ptrs,
       const std::shared_ptr<ReporterType>&);
   std::unique_ptr<InitializerType> BuildInitializer(
       const std::shared_ptr<formulation::updater::FixedUpdaterI>&,

--- a/src/framework/builder/framework_builder.h
+++ b/src/framework/builder/framework_builder.h
@@ -13,6 +13,7 @@
 #include "framework/builder/framework_validator.h"
 // Problem parameters
 #include "problem/parameters_i.h"
+#include "system/solution/solution_types.h"
 
 // Interface classes built by this factory
 #include "convergence/reporter/mpi_i.h"
@@ -27,6 +28,7 @@
 #include "formulation/updater/fission_source_updater_i.h"
 #include "formulation/updater/fixed_updater_i.h"
 #include "formulation/updater/scattering_source_updater_i.h"
+#include "formulation/updater/boundary_conditions_updater_i.h"
 #include "framework/framework_i.h"
 #include "iteration/group/group_solve_iteration_i.h"
 #include "iteration/initializer/initializer_i.h"
@@ -56,6 +58,9 @@ class FrameworkBuilder {
   using Color = utility::reporter::Color;
   using MomentCalculatorImpl = quadrature::MomentCalculatorImpl;
 
+  using AngularFluxStorage = system::solution::EnergyGroupToAngularSolutionPtrMap;
+
+  using BoundaryConditionsUpdaterType = formulation::updater::BoundaryConditionsUpdaterI;
   using CrossSectionType = data::CrossSections;
   using DiffusionFormulationType = formulation::scalar::DiffusionI<dim>;
   using DomainType = domain::DefinitionI<dim>;
@@ -80,6 +85,7 @@ class FrameworkBuilder {
   using SystemType = system::System;
 
   struct UpdaterPointers {
+    std::shared_ptr<BoundaryConditionsUpdaterType> boundary_conditions_updater_ptr = nullptr;
     std::shared_ptr<FissionSourceUpdaterType> fission_source_updater_ptr = nullptr;
     std::shared_ptr<FixedUpdaterType> fixed_updater_ptr = nullptr;
     std::shared_ptr<ScatteringSourceUpdaterType> scattering_source_updater_ptr = nullptr;
@@ -108,6 +114,12 @@ class FrameworkBuilder {
       std::unique_ptr<SAAFFormulationType>,
       std::unique_ptr<StamperType>,
       const std::shared_ptr<QuadratureSetType>&);
+  UpdaterPointers BuildUpdaterPointers(
+      std::unique_ptr<SAAFFormulationType>,
+      std::unique_ptr<StamperType>,
+      const std::shared_ptr<QuadratureSetType>&,
+      const std::map<problem::Boundary, bool>& reflective_boundaries,
+      const AngularFluxStorage&);
   std::unique_ptr<GroupSolveIterationType> BuildGroupSolveIteration(
       std::unique_ptr<SingleGroupSolverType>,
       std::unique_ptr<MomentConvergenceCheckerType>,

--- a/src/framework/builder/framework_builder.h
+++ b/src/framework/builder/framework_builder.h
@@ -10,6 +10,7 @@
 
 #include "utility/has_description.h"
 
+#include "framework/builder/framework_validator.h"
 // Problem parameters
 #include "problem/parameters_i.h"
 
@@ -189,8 +190,7 @@ class FrameworkBuilder {
   }
   std::string ReadMappingFile(std::string filename);
 
-  bool has_scattering_source_update_ = false;
-  bool has_fission_source_update_ = false;
+  FrameworkValidator validator_;
   bool build_report_closed_ = true;
 };
 

--- a/src/framework/builder/framework_builder.h
+++ b/src/framework/builder/framework_builder.h
@@ -163,7 +163,8 @@ class FrameworkBuilder {
   std::unique_ptr<SystemType> BuildSystem(const int n_groups, const int n_angles,
                                           const DomainType& domain,
                                           const std::size_t solution_size,
-                                          bool is_eigenvalue_problem = true);
+                                          bool is_eigenvalue_problem = true,
+                                          bool need_rhs_boundary_condition = false);
 
   FrameworkReporterType* reporter_ptr() { return reporter_ptr_.get(); }
 

--- a/src/framework/builder/framework_validator.cc
+++ b/src/framework/builder/framework_validator.cc
@@ -1,0 +1,13 @@
+#include "framework/builder/framework_validator.h"
+
+namespace bart {
+
+namespace framework {
+
+namespace builder {
+
+} // namespace builder
+
+} // namespace framework
+
+} // namespace bart

--- a/src/framework/builder/framework_validator.cc
+++ b/src/framework/builder/framework_validator.cc
@@ -31,6 +31,39 @@ std::set<FrameworkPart> FrameworkValidator::UnneededParts() const {
   }
   return return_set; }
 
+void FrameworkValidator::ReportValidation(
+    utility::reporter::BasicReporterI& to_report) const {
+  using Color = utility::reporter::Color;
+  bool issue = false;
+  to_report << "Validating framework components:\n";
+
+  for (const auto part : parts_) {
+    std::string description = framework_part_descriptions_.at(part);
+    description[0] = std::toupper(description[0]);
+    to_report << "\t";
+    if (needed_parts_.count(part) > 0) {
+      to_report << Color::Green << description << "\n";
+    } else {
+      to_report << Color::Yellow << description << " (Unneeded)\n";
+      issue = true;
+    }
+  }
+
+  for (const auto part : needed_parts_) {
+    if (parts_.count(part) == 0) {
+      std::string description = framework_part_descriptions_.at(part);
+      description[0] = std::toupper(description[0]);
+      to_report << "\t" << Color::Red << description << " (Missing)\n";
+      issue = true;
+    }
+  }
+
+  if (issue) {
+    to_report.Report("Warning: one or more issues identified during "
+                     "framework validation\n", Color::Yellow);
+  }
+}
+
 } // namespace builder
 
 } // namespace framework

--- a/src/framework/builder/framework_validator.cc
+++ b/src/framework/builder/framework_validator.cc
@@ -42,9 +42,9 @@ void FrameworkValidator::ReportValidation(
     description[0] = std::toupper(description[0]);
     to_report << "\t";
     if (needed_parts_.count(part) > 0) {
-      to_report << Color::Green << description << "\n";
+      to_report << Color::Green << description << "\n" << Color::Reset;
     } else {
-      to_report << Color::Yellow << description << " (Unneeded)\n";
+      to_report << Color::Yellow << description << " (Unneeded)\n" << Color::Reset;
       issue = true;
     }
   }
@@ -53,7 +53,7 @@ void FrameworkValidator::ReportValidation(
     if (parts_.count(part) == 0) {
       std::string description = framework_part_descriptions_.at(part);
       description[0] = std::toupper(description[0]);
-      to_report << "\t" << Color::Red << description << " (Missing)\n";
+      to_report << "\t" << Color::Red << description << " (Missing)\n" << Color::Reset;
       issue = true;
     }
   }

--- a/src/framework/builder/framework_validator.cc
+++ b/src/framework/builder/framework_validator.cc
@@ -6,6 +6,11 @@ namespace framework {
 
 namespace builder {
 
+FrameworkValidator &FrameworkValidator::AddPart(FrameworkPart to_add) {
+  parts_.insert(to_add);
+  return *this;
+}
+
 void FrameworkValidator::Parse(const problem::ParametersI& to_parse) {
   needed_parts_ = {FrameworkPart::ScatteringSourceUpdate};
   if (to_parse.IsEigenvalueProblem())
@@ -15,6 +20,17 @@ void FrameworkValidator::Parse(const problem::ParametersI& to_parse) {
     needed_parts_.insert(FrameworkPart::AngularSolutionStorage);
   }
 }
+
+std::set<FrameworkPart> FrameworkValidator::UnneededParts() const {
+  std::set<FrameworkPart> return_set;
+  if (HasUnneededParts()) {
+    for (const auto part : parts_) {
+      if (needed_parts_.count(part) == 0)
+        return_set.insert(part);
+    }
+  }
+  return return_set; }
+
 } // namespace builder
 
 } // namespace framework

--- a/src/framework/builder/framework_validator.cc
+++ b/src/framework/builder/framework_validator.cc
@@ -6,6 +6,12 @@ namespace framework {
 
 namespace builder {
 
+void FrameworkValidator::Parse(const problem::ParametersI& to_parse) {
+  needed_parts_are_present_.insert({FrameworkPart::ScatteringSourceUpdate,
+                                    false});
+  if (to_parse.IsEigenvalueProblem())
+    needed_parts_are_present_.insert({FrameworkPart::FissionSourceUpdate, false});
+}
 } // namespace builder
 
 } // namespace framework

--- a/src/framework/builder/framework_validator.cc
+++ b/src/framework/builder/framework_validator.cc
@@ -7,16 +7,12 @@ namespace framework {
 namespace builder {
 
 void FrameworkValidator::Parse(const problem::ParametersI& to_parse) {
-  needed_parts_are_present_ = {};
-  needed_parts_are_present_.insert({FrameworkPart::ScatteringSourceUpdate,
-                                    false});
+  needed_parts_ = {FrameworkPart::ScatteringSourceUpdate};
   if (to_parse.IsEigenvalueProblem())
-    needed_parts_are_present_.insert({FrameworkPart::FissionSourceUpdate,
-                                      false});
+    needed_parts_.insert(FrameworkPart::FissionSourceUpdate);
   if (to_parse.HaveReflectiveBC() == true &&
       to_parse.TransportModel() == problem::EquationType::kSelfAdjointAngularFlux) {
-    needed_parts_are_present_.insert({FrameworkPart::AngularSolutionStorage,
-                                      false});
+    needed_parts_.insert(FrameworkPart::AngularSolutionStorage);
   }
 }
 } // namespace builder

--- a/src/framework/builder/framework_validator.cc
+++ b/src/framework/builder/framework_validator.cc
@@ -7,10 +7,17 @@ namespace framework {
 namespace builder {
 
 void FrameworkValidator::Parse(const problem::ParametersI& to_parse) {
+  needed_parts_are_present_ = {};
   needed_parts_are_present_.insert({FrameworkPart::ScatteringSourceUpdate,
                                     false});
   if (to_parse.IsEigenvalueProblem())
-    needed_parts_are_present_.insert({FrameworkPart::FissionSourceUpdate, false});
+    needed_parts_are_present_.insert({FrameworkPart::FissionSourceUpdate,
+                                      false});
+  if (to_parse.HaveReflectiveBC() == true &&
+      to_parse.TransportModel() == problem::EquationType::kSelfAdjointAngularFlux) {
+    needed_parts_are_present_.insert({FrameworkPart::AngularSolutionStorage,
+                                      false});
+  }
 }
 } // namespace builder
 

--- a/src/framework/builder/framework_validator.h
+++ b/src/framework/builder/framework_validator.h
@@ -3,7 +3,7 @@
 
 #include "problem/parameters_i.h"
 
-#include <map>
+#include <set>
 
 namespace bart {
 
@@ -22,16 +22,27 @@ class FrameworkValidator {
   void Parse(const problem::ParametersI& to_parse);
 
   bool HasNeededParts() const {
-    return needed_parts_are_present_.size() > 0; }
+    return needed_parts_.size() > 0; }
 
-  std::vector<FrameworkPart> NeededParts() const {
-    std::vector<FrameworkPart> return_vector;
-    for (const auto part_pair : needed_parts_are_present_)
-      return_vector.push_back(part_pair.first);
-    return return_vector; }
+  bool HasUnneededParts() const {
+    return parts_.size() > needed_parts_.size(); }
+
+  std::set<FrameworkPart> NeededParts() const {
+    return needed_parts_; }
+
+  std::set<FrameworkPart> UnneededParts() const {
+    std::set<FrameworkPart> return_set;
+    if (HasUnneededParts()) {
+      for (const auto part : needed_parts_) {
+        if (parts_.count(part) > 0)
+          return_set.insert(part);
+      }
+    }
+    return return_set; }
  private:
 
-  std::map<FrameworkPart, bool> needed_parts_are_present_{};
+  std::set<FrameworkPart> needed_parts_{};
+  std::set<FrameworkPart> parts_{};
 
   std::map<FrameworkPart, std::string> framework_part_descriptions_{
       {FrameworkPart::ScatteringSourceUpdate, "scattering source updater"},

--- a/src/framework/builder/framework_validator.h
+++ b/src/framework/builder/framework_validator.h
@@ -19,8 +19,20 @@ enum class FrameworkPart {
 
 class FrameworkValidator {
  public:
+  void Parse(const problem::ParametersI& to_parse);
 
+  bool HasNeededParts() const {
+    return needed_parts_are_present_.size() > 0; }
+
+  std::vector<FrameworkPart> NeededParts() const {
+    std::vector<FrameworkPart> return_vector;
+    for (const auto part_pair : needed_parts_are_present_)
+      return_vector.push_back(part_pair.first);
+    return return_vector; }
  private:
+
+  std::map<FrameworkPart, bool> needed_parts_are_present_{};
+
   std::map<FrameworkPart, std::string> framework_part_descriptions_{
       {FrameworkPart::ScatteringSourceUpdate, "scattering source updater"},
       {FrameworkPart::FissionSourceUpdate, "fission source updater"},

--- a/src/framework/builder/framework_validator.h
+++ b/src/framework/builder/framework_validator.h
@@ -1,0 +1,38 @@
+#ifndef BART_SRC_FRAMEWORK_BUILDER_FRAMEWORK_VALIDATOR_H_
+#define BART_SRC_FRAMEWORK_BUILDER_FRAMEWORK_VALIDATOR_H_
+
+#include "problem/parameters_i.h"
+
+#include <map>
+
+namespace bart {
+
+namespace framework {
+
+namespace builder {
+
+enum class FrameworkPart {
+  ScatteringSourceUpdate = 0,
+  FissionSourceUpdate = 1,
+  AngularSolutionStorage = 2
+};
+
+class FrameworkValidator {
+ public:
+
+ private:
+  std::map<FrameworkPart, std::string> framework_part_descriptions_{
+      {FrameworkPart::ScatteringSourceUpdate, "scattering source updater"},
+      {FrameworkPart::FissionSourceUpdate, "fission source updater"},
+      {FrameworkPart::AngularSolutionStorage, "angular solution storage"}
+  };
+
+};
+
+} // namespace builder
+
+} // namespace framework
+
+} // namespace bart
+
+#endif //BART_SRC_FRAMEWORK_BUILDER_FRAMEWORK_VALIDATOR_H_

--- a/src/framework/builder/framework_validator.h
+++ b/src/framework/builder/framework_validator.h
@@ -19,26 +19,19 @@ enum class FrameworkPart {
 
 class FrameworkValidator {
  public:
-  void Parse(const problem::ParametersI& to_parse);
+  FrameworkValidator& AddPart(const FrameworkPart to_add);
 
   bool HasNeededParts() const {
     return needed_parts_.size() > 0; }
 
   bool HasUnneededParts() const {
     return parts_.size() > needed_parts_.size(); }
-
   std::set<FrameworkPart> NeededParts() const {
     return needed_parts_; }
-
-  std::set<FrameworkPart> UnneededParts() const {
-    std::set<FrameworkPart> return_set;
-    if (HasUnneededParts()) {
-      for (const auto part : needed_parts_) {
-        if (parts_.count(part) > 0)
-          return_set.insert(part);
-      }
-    }
-    return return_set; }
+  void Parse(const problem::ParametersI& to_parse);
+  std::set<FrameworkPart> Parts() const {
+    return parts_; }
+  std::set<FrameworkPart> UnneededParts() const;
  private:
 
   std::set<FrameworkPart> needed_parts_{};

--- a/src/framework/builder/framework_validator.h
+++ b/src/framework/builder/framework_validator.h
@@ -2,6 +2,7 @@
 #define BART_SRC_FRAMEWORK_BUILDER_FRAMEWORK_VALIDATOR_H_
 
 #include "problem/parameters_i.h"
+#include "utility/reporter/basic_reporter_i.h"
 
 #include <set>
 
@@ -31,6 +32,7 @@ class FrameworkValidator {
   void Parse(const problem::ParametersI& to_parse);
   std::set<FrameworkPart> Parts() const {
     return parts_; }
+  void ReportValidation(utility::reporter::BasicReporterI&) const;
   std::set<FrameworkPart> UnneededParts() const;
  private:
 

--- a/src/framework/builder/tests/framework_builder_integration_tests.cc
+++ b/src/framework/builder/tests/framework_builder_integration_tests.cc
@@ -270,9 +270,6 @@ TYPED_TEST(FrameworkBuilderIntegrationTest,
   system::SetUpEnergyGroupToAngularSolutionPtrMap(
       angular_flux_storage, this->n_energy_groups, this->n_angles);
 
-  EXPECT_CALL(*this->quadrature_set_sptr_, size())
-      .WillOnce(Return(this->n_angles));
-
   auto updater_struct = this->test_builder_ptr_->BuildUpdaterPointers(
       std::move(this->saaf_formulation_uptr_),
       std::move(this->stamper_uptr_),

--- a/src/framework/builder/tests/framework_validator_test.cc
+++ b/src/framework/builder/tests/framework_validator_test.cc
@@ -9,7 +9,7 @@ namespace  {
 using namespace bart;
 
 using ::testing::DoDefault, ::testing::NiceMock, ::testing::Return,
-::testing::UnorderedElementsAreArray;
+::testing::UnorderedElementsAreArray, ::testing::IsEmpty;
 
 using Part = framework::builder::FrameworkPart;
 
@@ -43,6 +43,7 @@ TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTestNonEigenvalue) {
               UnorderedElementsAreArray({Part::ScatteringSourceUpdate}));
   EXPECT_FALSE(test_validator.HasUnneededParts());
   EXPECT_EQ(test_validator.UnneededParts().size(), 0);
+  EXPECT_TRUE(test_validator.Parts().empty());
 }
 
 TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTestEigenvalue) {
@@ -57,6 +58,7 @@ TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTestEigenvalue) {
   EXPECT_THAT(test_validator.NeededParts(),
               UnorderedElementsAreArray({Part::FissionSourceUpdate,
                                          Part::ScatteringSourceUpdate}));
+  EXPECT_TRUE(test_validator.Parts().empty());
 }
 
 TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTestSAAFWithoutReflective) {
@@ -72,6 +74,7 @@ TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTestSAAFWithoutReflective) {
   EXPECT_THAT(test_validator.NeededParts(),
               UnorderedElementsAreArray({Part::FissionSourceUpdate,
                                          Part::ScatteringSourceUpdate}));
+  EXPECT_TRUE(test_validator.Parts().empty());
 }
 
 TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTestSAAFWithReflective) {
@@ -89,6 +92,31 @@ TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTestSAAFWithReflective) {
               UnorderedElementsAreArray({Part::FissionSourceUpdate,
                                          Part::ScatteringSourceUpdate,
                                          Part::AngularSolutionStorage}));
+  EXPECT_TRUE(test_validator.Parts().empty());
+}
+
+TEST_F(FrameworkBuilderFrameworkValidatorTest, AddPart) {
+  test_validator.Parse(mock_parameters);
+  EXPECT_TRUE(test_validator.Parts().empty());
+  test_validator
+      .AddPart(Part::ScatteringSourceUpdate)
+      .AddPart(Part::FissionSourceUpdate);
+  EXPECT_THAT(test_validator.NeededParts(),
+              UnorderedElementsAreArray({Part::ScatteringSourceUpdate,
+                                         Part::FissionSourceUpdate}));
+  EXPECT_THAT(test_validator.Parts(),
+              UnorderedElementsAreArray({Part::ScatteringSourceUpdate,
+                                         Part::FissionSourceUpdate}));
+  EXPECT_FALSE(test_validator.HasUnneededParts());
+  EXPECT_TRUE(test_validator.UnneededParts().empty());
+  test_validator.AddPart(Part::AngularSolutionStorage);
+  EXPECT_THAT(test_validator.Parts(),
+              UnorderedElementsAreArray({Part::ScatteringSourceUpdate,
+                                         Part::FissionSourceUpdate,
+                                         Part::AngularSolutionStorage}));
+  EXPECT_TRUE(test_validator.HasUnneededParts());
+  EXPECT_THAT(test_validator.UnneededParts(),
+              UnorderedElementsAreArray({Part::AngularSolutionStorage}));
 }
 
 } // namespace

--- a/src/framework/builder/tests/framework_validator_test.cc
+++ b/src/framework/builder/tests/framework_validator_test.cc
@@ -9,7 +9,9 @@ namespace  {
 using namespace bart;
 
 using ::testing::DoDefault, ::testing::NiceMock, ::testing::Return,
-::testing::UnorderedElementsAreArray, ::testing::IsEmpty;
+::testing::UnorderedElementsAreArray, ::testing::IsEmpty,
+::testing::HasSubstr, ::testing::ReturnRef, ::testing::A, ::testing::AllOf,
+::testing::_;
 
 using Part = framework::builder::FrameworkPart;
 
@@ -17,6 +19,7 @@ class FrameworkBuilderFrameworkValidatorTest : public ::testing::Test {
  public:
   framework::builder::FrameworkValidator test_validator;
   NiceMock<problem::ParametersMock> mock_parameters;
+  NiceMock<utility::reporter::BasicReporterMock> mock_reporter;
 
   void SetUp() override;
 };
@@ -28,6 +31,8 @@ void FrameworkBuilderFrameworkValidatorTest::SetUp() {
       .WillByDefault(Return(problem::EquationType::kDiffusion));
   ON_CALL(mock_parameters, HaveReflectiveBC())
       .WillByDefault(Return(false));
+  ON_CALL(mock_reporter, Instream(A<utility::reporter::Color>()))
+      .WillByDefault(ReturnRef(mock_reporter));
 }
 
 TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTestNonEigenvalue) {
@@ -118,5 +123,67 @@ TEST_F(FrameworkBuilderFrameworkValidatorTest, AddPart) {
   EXPECT_THAT(test_validator.UnneededParts(),
               UnorderedElementsAreArray({Part::AngularSolutionStorage}));
 }
+
+TEST_F(FrameworkBuilderFrameworkValidatorTest, ReportValidationMissing) {
+  test_validator.Parse(mock_parameters);
+
+  std::set<Part> expected_parts{Part::ScatteringSourceUpdate,
+                                Part::FissionSourceUpdate};
+
+  EXPECT_CALL(mock_reporter, Instream(utility::reporter::Color::Red))
+      .Times(::testing::AtLeast(2));
+  EXPECT_CALL(mock_reporter, Instream(utility::reporter::Color::Reset))
+      .Times(::testing::AtLeast(2));
+  EXPECT_CALL(mock_reporter, Instream(A<const std::string&>()))
+      .Times(::testing::AtLeast(2))
+      .WillRepeatedly(ReturnRef(mock_reporter));
+  EXPECT_CALL(mock_reporter, Report(_,utility::reporter::Color::Yellow));
+
+  test_validator.ReportValidation(mock_reporter);
+}
+
+TEST_F(FrameworkBuilderFrameworkValidatorTest, ReportValidationPresent) {
+  test_validator.Parse(mock_parameters);
+
+  std::set<Part> expected_parts{Part::ScatteringSourceUpdate,
+                                Part::FissionSourceUpdate};
+  EXPECT_EQ(test_validator.NeededParts(), expected_parts);
+  test_validator
+      .AddPart(Part::ScatteringSourceUpdate)
+      .AddPart(Part::FissionSourceUpdate);
+
+  EXPECT_CALL(mock_reporter, Instream(utility::reporter::Color::Green))
+      .Times(::testing::AtLeast(2));
+  EXPECT_CALL(mock_reporter, Instream(utility::reporter::Color::Reset))
+      .Times(::testing::AtLeast(2));
+  EXPECT_CALL(mock_reporter, Instream(A<const std::string&>()))
+      .Times(::testing::AtLeast(2))
+      .WillRepeatedly(ReturnRef(mock_reporter));
+
+  test_validator.ReportValidation(mock_reporter);
+}
+
+TEST_F(FrameworkBuilderFrameworkValidatorTest, ReportValidationMixed) {
+  test_validator.Parse(mock_parameters);
+
+  std::set<Part> expected_parts{Part::ScatteringSourceUpdate,
+                                Part::FissionSourceUpdate};
+
+  test_validator
+      .AddPart(Part::ScatteringSourceUpdate)
+      .AddPart(Part::AngularSolutionStorage);
+  EXPECT_CALL(mock_reporter, Instream(utility::reporter::Color::Green));
+  EXPECT_CALL(mock_reporter, Instream(utility::reporter::Color::Yellow));
+  EXPECT_CALL(mock_reporter, Instream(utility::reporter::Color::Red));
+  EXPECT_CALL(mock_reporter, Instream(A<const std::string&>()))
+      .Times(::testing::AtLeast(3))
+      .WillRepeatedly(ReturnRef(mock_reporter));
+  EXPECT_CALL(mock_reporter, Instream(utility::reporter::Color::Reset))
+      .Times(::testing::AtLeast(3));
+  EXPECT_CALL(mock_reporter, Report(_,utility::reporter::Color::Yellow));
+
+  test_validator.ReportValidation(mock_reporter);
+}
+
 
 } // namespace

--- a/src/framework/builder/tests/framework_validator_test.cc
+++ b/src/framework/builder/tests/framework_validator_test.cc
@@ -1,20 +1,48 @@
-#include "test_helpers/gmock_wrapper.h"
-
 #include "framework/builder/framework_validator.h"
+
 #include "problem/tests/parameters_mock.h"
+#include "test_helpers/gmock_wrapper.h"
 #include "utility/reporter/tests/basic_reporter_mock.h"
 
 namespace  {
 
 using namespace bart;
 
+using ::testing::UnorderedElementsAreArray, ::testing::Return;
+
+using Part = framework::builder::FrameworkPart;
+
 class FrameworkBuilderFrameworkValidatorTest : public ::testing::Test {
  public:
   framework::builder::FrameworkValidator test_validator;
+  problem::ParametersMock mock_parameters;
 };
 
-TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTest) {
+TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTestNonEigenvalue) {
+  EXPECT_FALSE(test_validator.HasNeededParts());
 
+  EXPECT_CALL(mock_parameters, IsEigenvalueProblem())
+      .WillOnce(Return(false));
+
+  test_validator.Parse(mock_parameters);
+
+  EXPECT_TRUE(test_validator.HasNeededParts());
+  EXPECT_THAT(test_validator.NeededParts(),
+              UnorderedElementsAreArray({Part::ScatteringSourceUpdate}));
+}
+
+TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTestEigenvalue) {
+  EXPECT_FALSE(test_validator.HasNeededParts());
+
+  EXPECT_CALL(mock_parameters, IsEigenvalueProblem())
+      .WillOnce(Return(true));
+
+  test_validator.Parse(mock_parameters);
+
+  EXPECT_TRUE(test_validator.HasNeededParts());
+  EXPECT_THAT(test_validator.NeededParts(),
+              UnorderedElementsAreArray({Part::FissionSourceUpdate,
+                                         Part::ScatteringSourceUpdate}));
 }
 
 } // namespace

--- a/src/framework/builder/tests/framework_validator_test.cc
+++ b/src/framework/builder/tests/framework_validator_test.cc
@@ -41,6 +41,8 @@ TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTestNonEigenvalue) {
   EXPECT_TRUE(test_validator.HasNeededParts());
   EXPECT_THAT(test_validator.NeededParts(),
               UnorderedElementsAreArray({Part::ScatteringSourceUpdate}));
+  EXPECT_FALSE(test_validator.HasUnneededParts());
+  EXPECT_EQ(test_validator.UnneededParts().size(), 0);
 }
 
 TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTestEigenvalue) {

--- a/src/framework/builder/tests/framework_validator_test.cc
+++ b/src/framework/builder/tests/framework_validator_test.cc
@@ -1,0 +1,20 @@
+#include "test_helpers/gmock_wrapper.h"
+
+#include "framework/builder/framework_validator.h"
+#include "problem/tests/parameters_mock.h"
+#include "utility/reporter/tests/basic_reporter_mock.h"
+
+namespace  {
+
+using namespace bart;
+
+class FrameworkBuilderFrameworkValidatorTest : public ::testing::Test {
+ public:
+  framework::builder::FrameworkValidator test_validator;
+};
+
+TEST_F(FrameworkBuilderFrameworkValidatorTest, ParseTest) {
+
+}
+
+} // namespace

--- a/src/iteration/group/group_solve_iteration.cc
+++ b/src/iteration/group/group_solve_iteration.cc
@@ -129,10 +129,9 @@ void GroupSolveIteration<dim>::StoreAngularSolution(system::System& system,
                                                     const int group) {
   for (int angle = 0; angle < system.total_angles; ++angle) {
     auto& stored_solution = angular_solution_ptr_map_.at(
-        system::EnergyGroup(group))->GetSolution(angle);
+        system::SolutionIndex(group, angle));
     auto& current_solution = group_solution_ptr_->GetSolution(angle);
-    stored_solution = current_solution;
-    stored_solution.compress(dealii::VectorOperation::insert);
+    *stored_solution = current_solution;
   }
 }
 

--- a/src/iteration/group/group_solve_iteration.cc
+++ b/src/iteration/group/group_solve_iteration.cc
@@ -44,12 +44,7 @@ void GroupSolveIteration<dim>::Iterate(system::System &system) {
     reporter_ptr_->Report("..Inner group iteration\n");
 
   for (int group = 0; group < total_groups; ++group) {
-    if (reporter_ptr_ != nullptr) {
-      std::string report{"....Group: "};
-      report += std::to_string(group);
-      report += "\n";
-      reporter_ptr_->Report(report);
-    }
+    PerformPerGroup(system, group);
 
     convergence::Status convergence_status;
     convergence_checker_ptr_->Reset();
@@ -114,6 +109,17 @@ void GroupSolveIteration<dim>::UpdateCurrentMoments(system::System &system,
       current_moments[{group, l, m}] = moment_calculator_ptr_->CalculateMoment(
           group_solution_ptr_.get(), group, l, m);
     }
+  }
+}
+
+template<int dim>
+void GroupSolveIteration<dim>::PerformPerGroup(system::System &system,
+                                               const int group) {
+  if (reporter_ptr_ != nullptr) {
+    std::string report{"....Group: "};
+    report += std::to_string(group);
+    report += "\n";
+    reporter_ptr_->Report(report);
   }
 }
 

--- a/src/iteration/group/group_solve_iteration.h
+++ b/src/iteration/group/group_solve_iteration.h
@@ -39,6 +39,7 @@ class GroupSolveIteration : public GroupSolveIterationI {
       EnergyGroupToAngularSolutionPtrMap& to_update) {
     is_storing_angular_solution_ = true;
     angular_solution_ptr_map_ = to_update;
+    return *this;
   }
 
   virtual ~GroupSolveIteration() = default;
@@ -76,6 +77,7 @@ class GroupSolveIteration : public GroupSolveIterationI {
  protected:
   virtual void PerformPerGroup(system::System& system, const int group);
   virtual void SolveGroup(const int group, system::System &system);
+  virtual void StoreAngularSolution(system::System& system, const int group);
   virtual system::moments::MomentVector GetScalarFlux(const int group,
                                                       system::System& system);
   virtual convergence::Status CheckConvergence(

--- a/src/iteration/group/group_solve_iteration.h
+++ b/src/iteration/group/group_solve_iteration.h
@@ -57,7 +57,7 @@ class GroupSolveIteration : public GroupSolveIterationI {
   }
 
  protected:
-
+  virtual void PerformPerGroup(system::System& system, const int group);
   virtual void SolveGroup(const int group, system::System &system);
   virtual system::moments::MomentVector GetScalarFlux(const int group,
                                                       system::System& system);

--- a/src/iteration/group/group_solve_iteration.h
+++ b/src/iteration/group/group_solve_iteration.h
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include "solver/group/single_group_solver_i.h"
+#include "system/solution/solution_types.h"
 
 namespace bart {
 
@@ -25,6 +26,7 @@ class GroupSolveIteration : public GroupSolveIterationI {
   using MomentCalculator = quadrature::calculators::SphericalHarmonicMomentsI;
   using GroupSolution = system::solution::MPIGroupAngularSolutionI;
   using Reporter = convergence::reporter::MpiI;
+  using EnergyGroupToAngularSolutionPtrMap = system::solution::EnergyGroupToAngularSolutionPtrMap;
 
   GroupSolveIteration(
       std::unique_ptr<GroupSolver> group_solver_ptr,
@@ -32,9 +34,24 @@ class GroupSolveIteration : public GroupSolveIterationI {
       std::unique_ptr<MomentCalculator> moment_calculator_ptr,
       const std::shared_ptr<GroupSolution> &group_solution_ptr,
       const std::shared_ptr<Reporter> &reporter_ptr = nullptr);
+
+  GroupSolveIteration& UpdateThisAngularSolutionMap(
+      EnergyGroupToAngularSolutionPtrMap& to_update) {
+    is_storing_angular_solution_ = true;
+    angular_solution_ptr_map_ = to_update;
+  }
+
   virtual ~GroupSolveIteration() = default;
 
   void Iterate(system::System &system) override;
+
+  bool is_storing_angular_solution() const {
+    return is_storing_angular_solution_;
+  }
+
+  EnergyGroupToAngularSolutionPtrMap angular_solution_ptr_map() const {
+    return angular_solution_ptr_map_;
+  }
 
   GroupSolver* group_solver_ptr() const {
     return group_solver_ptr_.get();
@@ -73,6 +90,8 @@ class GroupSolveIteration : public GroupSolveIterationI {
   std::unique_ptr<MomentCalculator> moment_calculator_ptr_ = nullptr;
   std::shared_ptr<GroupSolution> group_solution_ptr_ = nullptr;
   std::shared_ptr<Reporter> reporter_ptr_ = nullptr;
+  bool is_storing_angular_solution_ = false;
+  EnergyGroupToAngularSolutionPtrMap angular_solution_ptr_map_;
 };
 
 } // namespace group

--- a/src/iteration/group/group_source_iteration.cc
+++ b/src/iteration/group/group_source_iteration.cc
@@ -47,7 +47,8 @@ GroupSourceIteration<dim>::GroupSourceIteration(
   AssertThrow(boundary_condition_updater_ptr_ != nullptr,
       dealii::ExcMessage("Boundary conditions updater pointer passed to "
                          "GroupSolveIteration constructor is null"));
-
+  this->set_description("Group source iteration w/boundary conditions update",
+                        utility::DefaultImplementation(true));
 }
 
 template<int dim>

--- a/src/iteration/group/group_source_iteration.cc
+++ b/src/iteration/group/group_source_iteration.cc
@@ -28,6 +28,29 @@ GroupSourceIteration<dim>::GroupSourceIteration(
 }
 
 template<int dim>
+GroupSourceIteration<dim>::GroupSourceIteration(
+    std::unique_ptr<GroupSolver> group_solver_ptr,
+    std::unique_ptr<ConvergenceChecker> convergence_checker_ptr,
+    std::unique_ptr<MomentCalculator> moment_calculator_ptr,
+    const std::shared_ptr<GroupSolution> &group_solution_ptr,
+    const std::shared_ptr<SourceUpdater> &source_updater_ptr,
+    const std::shared_ptr<BoundaryConditionsUpdater> &boundary_condition_updater_ptr,
+    const std::shared_ptr<Reporter> &reporter_ptr)
+    : GroupSourceIteration<dim>::GroupSourceIteration(
+        std::move(group_solver_ptr),
+        std::move(convergence_checker_ptr),
+        std::move(moment_calculator_ptr),
+        group_solution_ptr,
+        source_updater_ptr,
+        reporter_ptr) {
+  boundary_condition_updater_ptr_ = boundary_condition_updater_ptr;
+  AssertThrow(boundary_condition_updater_ptr_ != nullptr,
+      dealii::ExcMessage("Boundary conditions updater pointer passed to "
+                         "GroupSolveIteration constructor is null"));
+
+}
+
+template<int dim>
 void GroupSourceIteration<dim>::UpdateSystem(system::System &system,
     const int group, const int angle) {
   this->source_updater_ptr_->UpdateScatteringSource(system,

--- a/src/iteration/group/group_source_iteration.cc
+++ b/src/iteration/group/group_source_iteration.cc
@@ -58,6 +58,19 @@ void GroupSourceIteration<dim>::UpdateSystem(system::System &system,
       system::EnergyGroup(group),
       quadrature::QuadraturePointIndex(angle));
 }
+template<int dim>
+void GroupSourceIteration<dim>::PerformPerGroup(system::System &system,
+                                                const int group) {
+  GroupSolveIteration<dim>::PerformPerGroup(system, group);
+  if (boundary_condition_updater_ptr_ != nullptr) {
+    for (int angle = 0; angle < system.total_angles; ++angle) {
+      boundary_condition_updater_ptr_->UpdateBoundaryConditions(
+          system,
+          system::EnergyGroup(group),
+          quadrature::QuadraturePointIndex(angle));
+    }
+  }
+}
 
 template class GroupSourceIteration<1>;
 template class GroupSourceIteration<2>;

--- a/src/iteration/group/group_source_iteration.h
+++ b/src/iteration/group/group_source_iteration.h
@@ -3,6 +3,7 @@
 
 #include "iteration/group/group_solve_iteration.h"
 #include "formulation/updater/scattering_source_updater_i.h"
+#include "formulation/updater/boundary_conditions_updater_i.h"
 
 namespace bart {
 
@@ -20,6 +21,7 @@ class GroupSourceIteration : public GroupSolveIteration<dim> {
   using typename GroupSolveIteration<dim>::Reporter;
 
   using SourceUpdater = formulation::updater::ScatteringSourceUpdaterI;
+  using BoundaryConditionsUpdater = formulation::updater::BoundaryConditionsUpdaterI;
 
   GroupSourceIteration(
       std::unique_ptr<GroupSolver> group_solver_ptr,
@@ -28,11 +30,22 @@ class GroupSourceIteration : public GroupSolveIteration<dim> {
       const std::shared_ptr<GroupSolution> &group_solution_ptr,
       const std::shared_ptr<SourceUpdater> &source_updater_ptr,
       const std::shared_ptr<Reporter> &reporter_ptr = nullptr);
+  GroupSourceIteration(
+      std::unique_ptr<GroupSolver> group_solver_ptr,
+      std::unique_ptr<ConvergenceChecker> convergence_checker_ptr,
+      std::unique_ptr<MomentCalculator> moment_calculator_ptr,
+      const std::shared_ptr<GroupSolution> &group_solution_ptr,
+      const std::shared_ptr<SourceUpdater> &source_updater_ptr,
+      const std::shared_ptr<BoundaryConditionsUpdater>& boundary_condition_updater_ptr,
+      const std::shared_ptr<Reporter> &reporter_ptr = nullptr);
   virtual ~GroupSourceIteration() = default;
 
-  SourceUpdater* source_updater_ptr() const { return source_updater_ptr_.get(); };
+  BoundaryConditionsUpdater* boundary_conditions_updater_ptr() const {
+    return boundary_condition_updater_ptr_.get(); }
+  SourceUpdater* source_updater_ptr() const { return source_updater_ptr_.get(); }
 
  protected:
+  std::shared_ptr<BoundaryConditionsUpdater> boundary_condition_updater_ptr_;
   std::shared_ptr<SourceUpdater> source_updater_ptr_;
   void UpdateSystem(system::System &system, const int group,
                     const int angle) override;

--- a/src/iteration/group/group_source_iteration.h
+++ b/src/iteration/group/group_source_iteration.h
@@ -49,6 +49,8 @@ class GroupSourceIteration : public GroupSolveIteration<dim> {
   std::shared_ptr<SourceUpdater> source_updater_ptr_;
   void UpdateSystem(system::System &system, const int group,
                     const int angle) override;
+  virtual void PerformPerGroup(system::System& system,
+                               const int group) override;
 
 };
 

--- a/src/iteration/group/tests/group_source_iteration_test.cc
+++ b/src/iteration/group/tests/group_source_iteration_test.cc
@@ -331,6 +331,11 @@ TYPED_TEST(IterationGroupSourceSystemSolvingTest, Iterate) {
           quadrature::QuadraturePointIndex(angle)))
           .Times(AtLeast(1))
           .WillRepeatedly(Update(this));
+      EXPECT_CALL(*this->boundary_conditions_updater_ptr_,
+                  UpdateBoundaryConditions(
+                      Ref(this->test_system),
+                          bart::system::EnergyGroup(group),
+                          quadrature::QuadraturePointIndex(angle)));
     }
   }
 

--- a/src/quadrature/tests/quadrature_set_mock.h
+++ b/src/quadrature/tests/quadrature_set_mock.h
@@ -15,24 +15,23 @@ class QuadratureSetMock : public QuadratureSetI<dim> {
   using typename QuadratureSetI<dim>::Iterator;
   using typename QuadratureSetI<dim>::ConstIterator;
 
-  MOCK_METHOD1_T(AddPoint, bool(std::shared_ptr<QuadraturePointI<dim>>));
-  MOCK_METHOD2_T(SetReflection, void(std::shared_ptr<QuadraturePointI<dim>>,
-      std::shared_ptr<QuadraturePointI<dim>>));
-  MOCK_CONST_METHOD1_T(GetReflection, std::shared_ptr<QuadraturePointI<dim>>(
-      std::shared_ptr<QuadraturePointI<dim>>));
-  MOCK_CONST_METHOD1_T(GetReflectionIndex, std::optional<int> (
-      std::shared_ptr<QuadraturePointI<dim>>));
-  MOCK_CONST_METHOD1_T(GetQuadraturePoint,
-      std::shared_ptr<QuadraturePointI<dim>>(QuadraturePointIndex));
-  MOCK_CONST_METHOD1_T(GetQuadraturePointIndex, int(
-      std::shared_ptr<QuadraturePointI<dim>>));
-  MOCK_CONST_METHOD0_T(quadrature_point_indices, std::set<int>());
-  MOCK_METHOD0_T(begin, Iterator());
-  MOCK_METHOD0_T(end, Iterator());
-  MOCK_CONST_METHOD0_T(cbegin, ConstIterator());
-  MOCK_CONST_METHOD0_T(cend, ConstIterator());
-
-  MOCK_CONST_METHOD0_T(size, std::size_t());
+  MOCK_METHOD(bool, AddPoint, (std::shared_ptr<QuadraturePointI<dim>>), (override));
+  MOCK_METHOD(void, SetReflection, (std::shared_ptr<QuadraturePointI<dim>>,
+      std::shared_ptr<QuadraturePointI<dim>>), (override));
+  MOCK_METHOD(std::shared_ptr<QuadraturePointI<dim>>, GetReflection,
+              (std::shared_ptr<QuadraturePointI<dim>>), (override, const));
+  MOCK_METHOD(std::optional<int>, GetReflectionIndex,
+              (std::shared_ptr<QuadraturePointI<dim>>), (override, const));
+  MOCK_METHOD(std::shared_ptr<QuadraturePointI<dim>>, GetQuadraturePoint,
+              (QuadraturePointIndex), (override, const));
+  MOCK_METHOD(int, GetQuadraturePointIndex,
+              (std::shared_ptr<QuadraturePointI<dim>>), (override, const));
+  MOCK_METHOD(std::set<int>, quadrature_point_indices, (), (override, const));
+  MOCK_METHOD(Iterator, begin, (), (override));
+  MOCK_METHOD(Iterator, end, (), (override));
+  MOCK_METHOD(ConstIterator, cbegin, (), (override, const));
+  MOCK_METHOD(ConstIterator, cend, (), (override, const));
+  MOCK_METHOD(std::size_t, size, (), (override, const));
 
 
 };

--- a/src/system/solution/solution_types.h
+++ b/src/system/solution/solution_types.h
@@ -12,9 +12,9 @@ namespace system {
 
 namespace solution {
 
-using AngularSolutionPtr = std::shared_ptr<MPIGroupAngularSolutionI>;
+using AngularSolutionPtr = std::shared_ptr<dealii::Vector<double>>;
 
-using EnergyGroupToAngularSolutionPtrMap = std::map<EnergyGroup, AngularSolutionPtr>;
+using EnergyGroupToAngularSolutionPtrMap = std::map<SolutionIndex, AngularSolutionPtr>;
 
 } // namespace solution
 

--- a/src/system/solution/solution_types.h
+++ b/src/system/solution/solution_types.h
@@ -1,0 +1,25 @@
+#ifndef BART_SRC_SYSTEM_SOLUTION_SOLUTION_TYPES_H_
+#define BART_SRC_SYSTEM_SOLUTION_SOLUTION_TYPES_H_
+
+#include <map>
+
+#include "system/solution/mpi_group_angular_solution_i.h"
+#include "system/system_types.h"
+
+namespace bart {
+
+namespace system {
+
+namespace solution {
+
+using AngularSolutionPtr = std::shared_ptr<MPIGroupAngularSolutionI>;
+
+using EnergyGroupToAngularSolutionPtrMap = std::map<EnergyGroup, AngularSolutionPtr>;
+
+} // namespace solution
+
+} // namespace system
+
+} // namespace bart
+
+#endif //BART_SRC_SYSTEM_SOLUTION_SOLUTION_TYPES_H_

--- a/src/system/system_functions.cc
+++ b/src/system/system_functions.cc
@@ -117,9 +117,10 @@ void SetUpEnergyGroupToAngularSolutionPtrMap(
   using SolutionType = system::solution::MPIGroupAngularSolution;
 
   for (int group = 0; group < total_groups; ++group) {
-    to_setup.insert(
-        {system::EnergyGroup(group),
-         std::make_shared<SolutionType>(total_angles)});
+    for (int angle = 0; angle < total_angles; ++angle) {
+      to_setup.insert({system::SolutionIndex(group, angle),
+                       std::make_shared<dealii::Vector<double>>()});
+    };
   }
 }
 

--- a/src/system/system_functions.cc
+++ b/src/system/system_functions.cc
@@ -32,7 +32,8 @@ void SetUpMPIAngularSolution(
 void InitializeSystem(system::System &system_to_setup,
                  const int total_groups,
                  const int total_angles,
-                 const bool is_eigenvalue_problem) {
+                 const bool is_eigenvalue_problem,
+                 const bool is_rhs_boundary_term_variable) {
   using VariableLinearTerms = system::terms::VariableLinearTerms;
 
   std::string error_start{"Error: attempting to call Initialize System on a "
@@ -55,6 +56,10 @@ void InitializeSystem(system::System &system_to_setup,
   if (is_eigenvalue_problem) {
     system_to_setup.k_effective = 1.0;
     rhs_variable_terms.insert(VariableLinearTerms::kFissionSource);
+  }
+
+  if (is_rhs_boundary_term_variable) {
+    rhs_variable_terms.insert(VariableLinearTerms::kReflectiveBoundaryCondition);
   }
 
   system_to_setup.right_hand_side_ptr_ = std::move(

--- a/src/system/system_functions.cc
+++ b/src/system/system_functions.cc
@@ -2,6 +2,7 @@
 
 #include "system/terms/term.h"
 #include "system/moments/spherical_harmonic.h"
+#include "system/solution/mpi_group_angular_solution.h"
 
 namespace bart {
 
@@ -103,6 +104,18 @@ void SetUpSystemMoments(system::System& system_to_setup,
 
   initialize_moments(*system_to_setup.current_moments);
   initialize_moments(*system_to_setup.previous_moments);
+}
+void SetUpEnergyGroupToAngularSolutionPtrMap(
+    solution::EnergyGroupToAngularSolutionPtrMap& to_setup,
+    const int total_groups,
+    const int total_angles) {
+  using SolutionType = system::solution::MPIGroupAngularSolution;
+
+  for (int group = 0; group < total_groups; ++group) {
+    to_setup.insert(
+        {system::EnergyGroup(group),
+         std::make_shared<SolutionType>(total_angles)});
+  }
 }
 
 template void SetUpMPIAngularSolution<1>(system::solution::MPIGroupAngularSolutionI&, const domain::DefinitionI<1>&, const double);

--- a/src/system/system_functions.h
+++ b/src/system/system_functions.h
@@ -31,7 +31,8 @@ void SetUpMPIAngularSolution(
 void InitializeSystem(system::System& system_to_setup,
                       const int total_groups,
                       const int total_angles,
-                      const bool is_eigenvalue_problem = true);
+                      const bool is_eigenvalue_problem = true,
+                      const bool is_rhs_boundary_term_variable = false);
 
 template <int dim>
 void SetUpSystemTerms(system::System& system_to_setup,

--- a/src/system/system_functions.h
+++ b/src/system/system_functions.h
@@ -4,6 +4,7 @@
 #include "system/solution/mpi_group_angular_solution_i.h"
 #include "domain/definition_i.h"
 #include "system/system.h"
+#include "system/solution/solution_types.h"
 
 namespace bart {
 
@@ -38,6 +39,11 @@ void SetUpSystemTerms(system::System& system_to_setup,
 
 void SetUpSystemMoments(system::System& system_to_setup,
                         const std::size_t solution_size);
+
+void SetUpEnergyGroupToAngularSolutionPtrMap(
+    solution::EnergyGroupToAngularSolutionPtrMap& to_setup,
+    const int total_groups,
+    const int total_angles);
 
 } // namespace system
 

--- a/src/system/system_types.h
+++ b/src/system/system_types.h
@@ -19,11 +19,13 @@ namespace system {
 using GroupNumber = int;
 
 using EnergyGroup = bart::utility::NamedType<int, struct EnergyGroupParameter>;
+using AngleIdx = bart::utility::NamedType<int, struct AngleIdxParameter>;
 
 //! Angle index for rhs and lhs
 using AngleIndex = int;
 //! Index used to store and access rhs vectors and lhs matrices
 using Index = std::pair<GroupNumber, AngleIndex>;
+using SolutionIndex = std::pair<EnergyGroup, AngleIdx>;
 
 //! Sparse MPI vector for use in various system terms.
 using MPIVector = dealii::PETScWrappers::MPI::Vector;

--- a/src/system/terms/term_types.h
+++ b/src/system/terms/term_types.h
@@ -14,6 +14,7 @@ enum class VariableLinearTerms {
   kOther = 0,            //!< Other source
   kScatteringSource = 1, //!< Scattering source
   kFissionSource = 2,    //!< Fission source
+  kReflectiveBoundaryCondition = 3, //!< Reflective boundary conditions
 };
 
 //! Bilinear Terms that may vary iteration-to-iteration

--- a/src/system/tests/system_functions_tests.cc
+++ b/src/system/tests/system_functions_tests.cc
@@ -423,17 +423,17 @@ TEST_F(SystemFunctionsSetUpEnergyGroupToAngularSolutionPtrMapIntTests,
                                                   total_groups_,
                                                   total_angles_);
 
-  using ExpectedType = bart::system::solution::MPIGroupAngularSolution;
-  std::vector<int> groups{};
-  EXPECT_EQ(solution_map_.size(), total_groups_);
-  for (auto& [energy_group, solution_ptr] : solution_map_) {
+  using ExpectedType = dealii::Vector<double>;
+  std::vector<int> energy_groups{};
+  EXPECT_EQ(solution_map_.size(), total_groups_ * total_angles_);
+  for (auto& [index, solution_ptr] : solution_map_) {
+    auto [energy_group, angle] = index;
     ASSERT_THAT(solution_ptr.get(),
                 WhenDynamicCastTo<ExpectedType*>(NotNull()));
-    EXPECT_EQ(solution_ptr->total_angles(), total_angles_);
     EXPECT_LT(energy_group.get(), total_groups_);
     EXPECT_GE(energy_group.get(), 0);
-    EXPECT_EQ(std::count(groups.cbegin(), groups.cend(), energy_group.get()), 0);
-    groups.push_back(energy_group.get());
+    EXPECT_LT(angle.get(), total_angles_);
+    EXPECT_GE(angle.get(), 0);
   }
 }
 

--- a/src/system/tests/system_functions_tests.cc
+++ b/src/system/tests/system_functions_tests.cc
@@ -15,6 +15,7 @@
 #include "system/moments/tests/spherical_harmonic_mock.h"
 #include "system/terms/tests/linear_term_mock.h"
 #include "system/terms/tests/bilinear_term_mock.h"
+#include "system/solution/solution_types.h"
 
 namespace  {
 
@@ -373,5 +374,39 @@ TEST_F(SystemFunctionsSetUpSystemMomentsTests, SetUpProperly) {
     }
   }
 }
+
+// ===== SetUpSystemAngularSolution Tests ======================================
+
+class SystemFunctionsSetUpEnergyGroupToAngularSolutionPtrMapIntTests
+    : public ::testing::Test {
+ public:
+  system::solution::EnergyGroupToAngularSolutionPtrMap solution_map_;
+
+  const int total_groups_ = test_helpers::RandomDouble(2, 4);
+  const int total_angles_{total_groups_ + 1};
+
+};
+
+TEST_F(SystemFunctionsSetUpEnergyGroupToAngularSolutionPtrMapIntTests,
+       DefaultCall) {
+  system::SetUpEnergyGroupToAngularSolutionPtrMap(solution_map_,
+                                                  total_groups_,
+                                                  total_angles_);
+
+  using ExpectedType = bart::system::solution::MPIGroupAngularSolution;
+  std::vector<int> groups{};
+  EXPECT_EQ(solution_map_.size(), total_groups_);
+  for (auto& [energy_group, solution_ptr] : solution_map_) {
+    ASSERT_THAT(solution_ptr.get(),
+                WhenDynamicCastTo<ExpectedType*>(NotNull()));
+    EXPECT_EQ(solution_ptr->total_angles(), total_angles_);
+    EXPECT_LT(energy_group.get(), total_groups_);
+    EXPECT_GE(energy_group.get(), 0);
+    EXPECT_EQ(std::count(groups.cbegin(), groups.cend(), energy_group.get()), 0);
+    groups.push_back(energy_group.get());
+  }
+}
+
+
 
 } // namespace

--- a/src/utility/named_type.h
+++ b/src/utility/named_type.h
@@ -28,6 +28,9 @@ class NamedType
   bool operator==(const NamedType& rhs) const {
     return rhs.get() == value_;
   }
+  bool operator<(const NamedType& rhs) const {
+    return rhs.get() < value_;
+  }
  private:
   T value_;
 };


### PR DESCRIPTION
This pull request implements reflective boundary conditions for the Self-Adjoint Angular Flux formulation. This includes the following features to support reflective boundary conditions:

- Adds a new updater interface `BoundaryConditionUpdaterI`
- Adds `SAAFUpdater::UpdateBoundaryConditions`
- Adds angular solution storage as sequential vectors (`dealii::Vector<double>`) and function to initialize storage map.
- Updated `SAAFUpdater` to take angular solution storage if reflective boundary conditions are indicated.
- Adds `SelfAdjointAngularFlux::FillReflectiveBoundaryLinearTerm`
- Updated `GroupSourceIteration` constructor to take a boundary conditions updater class, if present, will update boundary conditions in `PerformPerGroup`
- Added reflective boundary conditions to types of variable linear terms.

This feature closes #149 

Other updates:

- Adds a `FiniteElement::ValueAtFaceQuadrature` function to extrapolate functions at cell face degrees of freedom to cell face quadrature points.
- Adds framework builder validator that will identify required parts of a solve based on the parameters handler and verify they are present.
- Added `GroupSolveIteration::PerformPerGroup` that is performed each time the solve of a particular group begins. By default it reports that the group is being solved.
- Updated `QuadratureSetMock` to new google mock format (see #151)
- Fixed a bug where `FiniteElement::ValueAtQuadrature` was returning an incorrectly sized vector (size was based on degrees of freedom instead of cell quadrature points).
- Updated `utility::NamedType` to have an `operator<` for use in an ordered map.
