### PR TITLE
1D Angular Quadrature Implementation

### DIFF
--- a/src/domain/definition.cc
+++ b/src/domain/definition.cc
@@ -55,11 +55,17 @@ Definition<1>::Definition(
 template <int dim>
 Definition<dim>& Definition<dim>::SetUpMesh() {
   // SetUp triangulation using the mesh dependency
+  return SetUpMesh(0);
+}
+
+template<int dim>
+Definition<dim>& Definition<dim>::SetUpMesh(const int global_refinements) {
   AssertThrow(mesh_->has_material_mapping(),
-                    dealii::ExcMessage("Mesh object must have initialized material mapping"));
+              dealii::ExcMessage("Mesh object must have initialized material mapping"));
   mesh_->FillTriangulation(triangulation_);
   mesh_->FillBoundaryID(triangulation_);
   mesh_->FillMaterialID(triangulation_);
+  triangulation_.refine_global(global_refinements);
   return *this;
 }
 
@@ -169,7 +175,6 @@ int Definition<dim>::total_degrees_of_freedom() const {
     total_degrees_of_freedom_ = dof_handler_.n_dofs();
   return total_degrees_of_freedom_;
 }
-
 
 template class Definition<1>;
 template class Definition<2>;

--- a/src/domain/definition.h
+++ b/src/domain/definition.h
@@ -74,6 +74,7 @@ class Definition : public DefinitionI<dim> {
 
   Definition<dim>& SetUpDOF() override;
   Definition<dim>& SetUpMesh() override;
+  Definition<dim>& SetUpMesh(const int global_refinements) override;
 
   dealii::FullMatrix<double> GetCellMatrix() const override {
     int cell_dofs = finite_element_->dofs_per_cell();

--- a/src/domain/definition_i.h
+++ b/src/domain/definition_i.h
@@ -47,11 +47,20 @@ class DefinitionI : public utility::HasDescription {
   /*! Set up the DOF handler, to access sparsity patterns, etc */
   virtual DefinitionI<dim>& SetUpDOF() = 0;
 
-/*! Fills triangulation with mesh defined in MeshI object
+  /*! \brief Fills triangulation with mesh defined in MeshI object
    * Creates mesh shape, sets up boundary ids and material ids. Requires that
    * the mesh has a material mapping setup.
    */
   virtual DefinitionI<dim>& SetUpMesh() = 0;
+
+  /*! \brief Fills triangulation with mesh defined in MeshI object.
+   *
+   * Creates mesh shape, sets up boundary ids and material ids. Requires that
+   * the mesh has a material mapping setup. Also performs global refinements.
+   *
+   * @param global_refinements number of global refinements to perform
+   */
+  virtual DefinitionI<dim>& SetUpMesh(const int global_refinements) = 0;
 
   /*! Get a matrix suitible for a cell matrix.
    *

--- a/src/domain/mesh/mesh_cartesian.cc
+++ b/src/domain/mesh/mesh_cartesian.cc
@@ -156,11 +156,12 @@ void MeshCartesian<dim>::FillBoundaryID(dealii::Triangulation<dim> &to_fill) {
                 face->set_boundary_id(static_cast<int>(Boundary::kXMax));
                 break;
               }
-              break;
+              [[fallthrough]];
             }
             default: {
               AssertThrow(false,
-                          dealii::ExcMessage("Unsupported number of dimensions in FillBoundaryID"));
+                          dealii::ExcMessage("The location of a boundary could "
+                                             "not be determined."))
             }
           }
         }

--- a/src/domain/tests/definition_mock.h
+++ b/src/domain/tests/definition_mock.h
@@ -21,6 +21,7 @@ class DefinitionMock : public DefinitionI<dim> {
   using typename DefinitionI<dim>::CellRange;
 
   MOCK_METHOD(DefinitionMock<dim>&, SetUpMesh, (), (override));
+  MOCK_METHOD(DefinitionMock<dim>&, SetUpMesh, (const int), (override));
   MOCK_METHOD(DefinitionMock<dim>&, SetUpDOF, (), (override));
   MOCK_METHOD(dealii::FullMatrix<double>, GetCellMatrix, (), (override, const));
   MOCK_METHOD(dealii::Vector<double>, GetCellVector, (), (override, const));

--- a/src/domain/tests/definition_test.cc
+++ b/src/domain/tests/definition_test.cc
@@ -94,11 +94,6 @@ class DomainDefinitionDOFTest : public DomainDefinitionTest<DimensionWrapper> {
   void SetUp() override;
   static void SetTriangulation(dealii::Triangulation<dim> &to_fill) {
     dealii::GridGenerator::hyper_cube(to_fill, -1, 1);
-//    if (dim == 1) {
-//      to_fill.refine_global(4);
-//    } else {
-//      to_fill.refine_global(2);
-//    }
   }
 };
 

--- a/src/domain/tests/definition_test.cc
+++ b/src/domain/tests/definition_test.cc
@@ -89,15 +89,16 @@ class DomainDefinitionDOFTest : public DomainDefinitionTest<DimensionWrapper> {
   dealii::Triangulation<dim> triangulation;
   dealii::FE_Q<dim> fe;
   int n_cells_;
+  int global_refinements_ = 2;
 
   void SetUp() override;
   static void SetTriangulation(dealii::Triangulation<dim> &to_fill) {
     dealii::GridGenerator::hyper_cube(to_fill, -1, 1);
-    if (dim == 1) {
-      to_fill.refine_global(4);
-    } else {
-      to_fill.refine_global(2);
-    }
+//    if (dim == 1) {
+//      to_fill.refine_global(4);
+//    } else {
+//      to_fill.refine_global(2);
+//    }
   }
 };
 
@@ -106,6 +107,9 @@ TYPED_TEST_CASE(DomainDefinitionDOFTest, bart::testing::AllDimensions);
 template <typename DimensionWrapper>
 void DomainDefinitionDOFTest<DimensionWrapper>::SetUp() {
   DomainDefinitionTest<DimensionWrapper>::SetUp();
+  if (this->dim == 1) {
+    global_refinements_ = 4;
+  }
 }
 
 TYPED_TEST(DomainDefinitionDOFTest, SetUpDOFTestMPI) {
@@ -118,7 +122,8 @@ TYPED_TEST(DomainDefinitionDOFTest, SetUpDOFTestMPI) {
 
   bart::domain::Definition<this->dim> test_domain(std::move(this->nice_mesh_ptr),
                                                   this->fe_ptr);
-  test_domain.SetUpMesh();
+
+  test_domain.SetUpMesh(this->global_refinements_);
   test_domain.SetUpDOF();
 
   EXPECT_EQ(test_domain.total_degrees_of_freedom(),
@@ -155,7 +160,7 @@ TYPED_TEST(DomainDefinitionDOFTest, SystemMatrixMPI) {
 
   bart::domain::Definition<this->dim> test_domain(std::move(this->nice_mesh_ptr),
                                                   this->fe_ptr);
-  test_domain.SetUpMesh();
+  test_domain.SetUpMesh(this->global_refinements_);
   test_domain.SetUpDOF();
 
   auto system_matrix_ptr = test_domain.MakeSystemMatrix();
@@ -175,7 +180,7 @@ TYPED_TEST(DomainDefinitionDOFTest, SystemVectorMPI) {
 
   bart::domain::Definition<this->dim> test_domain(std::move(this->nice_mesh_ptr),
                                                   this->fe_ptr);
-  test_domain.SetUpMesh();
+  test_domain.SetUpMesh(this->global_refinements_);
   test_domain.SetUpDOF();
 
   auto system_vector_ptr = test_domain.MakeSystemVector();

--- a/src/framework/builder/framework_builder.cc
+++ b/src/framework/builder/framework_builder.cc
@@ -574,17 +574,30 @@ auto FrameworkBuilder<dim>::BuildQuadratureSet(ParametersType problem_parameters
 
   const int order_value = problem_parameters.AngularQuadOrder();
   switch (problem_parameters.AngularQuad()) {
+    case problem::AngularQuadType::kLevelSymmetricGaussian: {
+      AssertThrow(dim == 3, dealii::ExcMessage("Error in BuildQuadratureSet "
+                                               "LSGC only available for 3D"))
+      quadrature_generator_ptr =
+          quadrature::factory::MakeAngularQuadratureGeneratorPtr<dim>(
+              quadrature::Order(order_value),
+              quadrature::AngularQuadratureSetType::kLevelSymmetricGaussian);
+      break;
+    }
+    case problem::AngularQuadType::kGaussLegendre: {
+      AssertThrow(dim == 1, dealii::ExcMessage("Error in BuildQuadratureSet "
+                                               "GaussLegendre only available "
+                                               "for 1D"))
+      quadrature_generator_ptr =
+          quadrature::factory::MakeAngularQuadratureGeneratorPtr<dim>(
+              quadrature::Order(order_value),
+              quadrature::AngularQuadratureSetType::kGaussLegendre);
+      break;
+    }
     default: {
-      if (dim == 3) {
-        quadrature_generator_ptr =
-            quadrature::factory::MakeAngularQuadratureGeneratorPtr<dim>(
-                quadrature::Order(order_value),
-                quadrature::AngularQuadratureSetType::kLevelSymmetricGaussian);
-      } else {
         AssertThrow(false,
                     dealii::ExcMessage("No supported quadratures for this dimension "
                                        "and transport model"))
-      }
+      break;
     }
   }
 

--- a/src/framework/builder/framework_builder.cc
+++ b/src/framework/builder/framework_builder.cc
@@ -600,6 +600,7 @@ auto FrameworkBuilder<dim>::BuildQuadratureSet(ParametersType problem_parameters
       break;
     }
   }
+  ReportBuildSuccess(quadrature_generator_ptr->description());
 
   return_ptr = quadrature::factory::MakeQuadratureSetPtr<dim>();
 

--- a/src/framework/builder/framework_builder.cc
+++ b/src/framework/builder/framework_builder.cc
@@ -87,7 +87,7 @@ auto FrameworkBuilder<dim>::BuildFramework(std::string name,
   auto domain_ptr = Shared(BuildDomain(prm, finite_element_ptr,
                                        ReadMappingFile(prm.MaterialMapFilename())));
   *reporter_ptr_ << "\tSetting up domain\n";
-  domain_ptr->SetUpMesh().SetUpDOF();
+  domain_ptr->SetUpMesh(prm.UniformRefinements()).SetUpDOF();
 
   // Various objects to be initialized
   std::shared_ptr<QuadratureSetType> quadrature_set_ptr = nullptr;

--- a/src/framework/builder/tests/framework_builder_integration_tests.cc
+++ b/src/framework/builder/tests/framework_builder_integration_tests.cc
@@ -420,6 +420,27 @@ TYPED_TEST(FrameworkBuilderIntegrationTest, BuildPowerIterationTest) {
                   WhenDynamicCastTo<ExpectedType*>(NotNull()));
 }
 
+TYPED_TEST(FrameworkBuilderIntegrationTest, BuildGaussLegendreQuadratureSet) {
+  constexpr int dim = this->dim;
+  const int order = 4;
+  EXPECT_CALL(this->parameters, AngularQuad())
+      .WillOnce(Return(problem::AngularQuadType::kGaussLegendre));
+  EXPECT_CALL(this->parameters, AngularQuadOrder())
+      .WillOnce(Return(order));
+
+  if (dim == 1) {
+    using ExpectedType = quadrature::QuadratureSet<dim>;
+    auto quadrature_set = this->test_builder_ptr_->BuildQuadratureSet(this->parameters);
+    ASSERT_NE(nullptr, quadrature_set);
+    ASSERT_NE(nullptr, dynamic_cast<ExpectedType*>(quadrature_set.get()));
+    EXPECT_EQ(quadrature_set->size(), 2*order);
+  } else {
+    EXPECT_ANY_THROW({
+      auto quadrature_set = this->test_builder_ptr_->BuildQuadratureSet(this->parameters);
+                     });
+  }
+}
+
 TYPED_TEST(FrameworkBuilderIntegrationTest, BuildLSAngularQuadratureSet) {
   constexpr int dim = this->dim;
   const int order = 4;

--- a/src/problem/parameter_types.h
+++ b/src/problem/parameter_types.h
@@ -8,6 +8,7 @@ namespace problem {
 enum class AngularQuadType {
   kNone,
   kLevelSymmetricGaussian,
+  kGaussLegendre
 };
 
 enum class DiscretizationType {

--- a/src/problem/parameters_dealii_handler.h
+++ b/src/problem/parameters_dealii_handler.h
@@ -311,7 +311,8 @@ class ParametersDealiiHandler : public ParametersI {
 
   const std::unordered_map<std::string, AngularQuadType> kAngularQuadTypeMap_ {
     {"level_symmetric_gaussian", AngularQuadType::kLevelSymmetricGaussian},
-    {"none", AngularQuadType::kNone},
+    {"gauss_legendre",           AngularQuadType::kGaussLegendre},
+    {"none",                     AngularQuadType::kNone},
   }; /*!< Maps angular quadrature type to strings used in parsed input files. */
 
   // Setup functions

--- a/src/quadrature/angular/gauss_legendre.cc
+++ b/src/quadrature/angular/gauss_legendre.cc
@@ -1,0 +1,17 @@
+#include "quadrature/angular/gauss_legendre.h"
+
+namespace bart {
+
+namespace quadrature {
+
+namespace angular {
+
+std::vector<GaussLegendre::PositionWeightPairType> GaussLegendre::GenerateSet() const {
+  return std::vector<PositionWeightPairType>();
+}
+
+} // namespace angular
+
+} // namespace quadrature
+
+} // namespace bart

--- a/src/quadrature/angular/gauss_legendre.cc
+++ b/src/quadrature/angular/gauss_legendre.cc
@@ -13,6 +13,7 @@ GaussLegendre::GaussLegendre(const int n_points)
   AssertThrow(n_points > 0,
       dealii::ExcMessage("Error in constructor of GaussLegendre, n_points must "
                          "be greater than or equal to 0"))
+  this->set_description("Gauss-Legendre quadrature (1D)");
 }
 
 

--- a/src/quadrature/angular/gauss_legendre.cc
+++ b/src/quadrature/angular/gauss_legendre.cc
@@ -1,13 +1,36 @@
 #include "quadrature/angular/gauss_legendre.h"
 
+#include <deal.II/base/quadrature_lib.h>
+
 namespace bart {
 
 namespace quadrature {
 
 namespace angular {
 
-std::vector<GaussLegendre::PositionWeightPairType> GaussLegendre::GenerateSet() const {
-  return std::vector<PositionWeightPairType>();
+GaussLegendre::GaussLegendre(const int n_points)
+    : n_points_(n_points) {
+  AssertThrow(n_points > 0,
+      dealii::ExcMessage("Error in constructor of GaussLegendre, n_points must "
+                         "be greater than or equal to 0"))
+}
+
+
+std::vector<GaussLegendre::PositionWeightPairType>
+    GaussLegendre::GenerateSet() const {
+  dealii::QGauss<1> gaussian_quadrature(n_points_);
+  std::vector<PositionWeightPairType> return_vector;
+
+  auto points = gaussian_quadrature.get_points();
+  auto weights = gaussian_quadrature.get_weights();
+
+  for (int i = 0; i < static_cast<int>(gaussian_quadrature.size()); ++i) {
+    CartesianPosition<1> x_position({points.at(i)[0]});
+    Weight weight(weights.at(i));
+    return_vector.push_back({x_position, weight});
+  }
+
+  return return_vector;
 }
 
 } // namespace angular

--- a/src/quadrature/angular/gauss_legendre.h
+++ b/src/quadrature/angular/gauss_legendre.h
@@ -11,9 +11,9 @@ namespace angular {
 
 /*! \brief Generates a 1D Gauss-Legendre quadrature set.
  *
- * The Gauss-Legendre polynomial set with $$n$$-points will integrate
- * polynomials up to degree $$2n-1$$ exactly. The points are generated on the
- * interval $$[0, 1]$$.
+ * The Gauss-Legendre polynomial set with \f$n\f$-points will integrate
+ * polynomials up to degree \f$2n-1\f$ exactly. The points are generated on the
+ * interval \f$[0, 1]\f$.
  *
  */
 class GaussLegendre : public QuadratureGeneratorI<1> {
@@ -23,7 +23,7 @@ class GaussLegendre : public QuadratureGeneratorI<1> {
 
   /*! \brief Constructor.
    *
-   * @param n_points number of points on $$[0, 1]$$
+   * @param n_points number of points on \f$[0, 1]\f$
    */
   GaussLegendre(const int n_points);
   virtual ~GaussLegendre() = default;

--- a/src/quadrature/angular/gauss_legendre.h
+++ b/src/quadrature/angular/gauss_legendre.h
@@ -1,0 +1,34 @@
+#ifndef BART_SRC_QUADRATURE_ANGULAR_GAUSS_LEGENDRE_H_
+#define BART_SRC_QUADRATURE_ANGULAR_GAUSS_LEGENDRE_H_
+
+#include "quadrature/quadrature_generator_i.h"
+
+namespace bart {
+
+namespace quadrature {
+
+namespace angular {
+
+/*! \brief 1D Gauss-Legendre quadrature set.
+ *
+ */
+class GaussLegendre : public QuadratureGeneratorI<1> {
+ public:
+  using PositionWeightPairType = std::pair<CartesianPosition<1>, Weight>;
+
+  GaussLegendre(const int n_points) : n_points_(n_points) {}
+  virtual ~GaussLegendre() = default;
+  virtual std::vector<PositionWeightPairType> GenerateSet() const;
+  virtual int order() const { return n_points_; };
+
+ private:
+  const int n_points_ = 0;
+};
+
+} // namespace angular
+
+} // namespace quadrature
+
+} // namespace bart
+
+#endif //BART_SRC_QUADRATURE_ANGULAR_GAUSS_LEGENDRE_H_

--- a/src/quadrature/angular/gauss_legendre.h
+++ b/src/quadrature/angular/gauss_legendre.h
@@ -9,20 +9,30 @@ namespace quadrature {
 
 namespace angular {
 
-/*! \brief 1D Gauss-Legendre quadrature set.
+/*! \brief Generates a 1D Gauss-Legendre quadrature set.
+ *
+ * The Gauss-Legendre polynomial set with $$n$$-points will integrate
+ * polynomials up to degree $$2n-1$$ exactly. The points are generated on the
+ * interval $$[0, 1]$$.
  *
  */
 class GaussLegendre : public QuadratureGeneratorI<1> {
  public:
+  //! Type for pairs of cartesian positions and weights
   using PositionWeightPairType = std::pair<CartesianPosition<1>, Weight>;
 
-  GaussLegendre(const int n_points) : n_points_(n_points) {}
+  /*! \brief Constructor.
+   *
+   * @param n_points number of points on $$[0, 1]$$
+   */
+  GaussLegendre(const int n_points);
   virtual ~GaussLegendre() = default;
   virtual std::vector<PositionWeightPairType> GenerateSet() const;
+  //! \brief Returns the number of points
   virtual int order() const { return n_points_; };
 
  private:
-  const int n_points_ = 0;
+  const int n_points_{0};
 };
 
 } // namespace angular

--- a/src/quadrature/angular/level_symmetric_gaussian.cc
+++ b/src/quadrature/angular/level_symmetric_gaussian.cc
@@ -20,6 +20,7 @@ LevelSymmetricGaussian::LevelSymmetricGaussian(bart::quadrature::Order order)
   AssertThrow(order_ <= 16,
               dealii::ExcMessage("Error in constructor of "
                                  "LevelSymmetricGaussian order must be <= 16"))
+  this->set_description("Level-symmetric-type Gaussian quadrature (3D)");
 }
 
 std::vector<std::pair<CartesianPosition<3>, Weight>>

--- a/src/quadrature/angular/tests/gauss_legendre_test.cc
+++ b/src/quadrature/angular/tests/gauss_legendre_test.cc
@@ -7,18 +7,24 @@ namespace  {
 
 using namespace bart;
 
+/* Tests for the quadrature::angular::GaussLegendre class. */
 class QuadratureAngularGaussLegendreTest : public ::testing::Test {
  public:
   QuadratureAngularGaussLegendreTest() : test_quadrature_(n_points) {}
-  quadrature::angular::GaussLegendre test_quadrature_;
-  const int n_points = 4;
 
+  // Object to be tested
+  quadrature::angular::GaussLegendre test_quadrature_;
+
+  // Test parameters
+  const int n_points = 4; // number of quadrature points
 };
 
+// Constructor given a valid number of points should not throw
 TEST_F(QuadratureAngularGaussLegendreTest, Constructor) {
   EXPECT_NO_THROW(quadrature::angular::GaussLegendre test_quadrature(n_points));
 }
 
+// Constructor given an invalid number of points should throw
 TEST_F(QuadratureAngularGaussLegendreTest, ConstructorBadNPoints) {
   auto bad_n_points = test_helpers::RandomVector(5, -5, 0);
   bad_n_points.push_back(0);
@@ -29,17 +35,22 @@ TEST_F(QuadratureAngularGaussLegendreTest, ConstructorBadNPoints) {
   }
 }
 
+// Order getter should return number of points
 TEST_F(QuadratureAngularGaussLegendreTest, Order) {
   EXPECT_EQ(n_points, test_quadrature_.order());
 }
 
+/* Generate set should return a set of points and weights that exactly
+ * integrate a polynomial (Legendre is used here). P_1 Legendre polynomial
+ * integrates to 0.4 over [-1, 1]. The quadrature set will numerically integrate
+ * over [0, 1] so the final result is multiplied by 2 before checking. */
 TEST_F(QuadratureAngularGaussLegendreTest, GenerateSet) {
   auto set = test_quadrature_.GenerateSet();
   EXPECT_EQ(set.size(), n_points);
 
   double sum{0.0};
 
-  // P_1 Legendre polynomial should integrate to 0.4 over [-1, 1]
+  // P_1 Legendre polynomial integrates to 0.4 over [-1, 1]
   auto legendre = [](const double point) {
     return 0.5 * (3*point*point - 1);
   };

--- a/src/quadrature/angular/tests/gauss_legendre_test.cc
+++ b/src/quadrature/angular/tests/gauss_legendre_test.cc
@@ -1,0 +1,56 @@
+#include "quadrature/angular/gauss_legendre.h"
+
+#include "test_helpers/test_helper_functions.h"
+#include "test_helpers/gmock_wrapper.h"
+
+namespace  {
+
+using namespace bart;
+
+class QuadratureAngularGaussLegendreTest : public ::testing::Test {
+ public:
+  QuadratureAngularGaussLegendreTest() : test_quadrature_(n_points) {}
+  quadrature::angular::GaussLegendre test_quadrature_;
+  const int n_points = 4;
+
+};
+
+TEST_F(QuadratureAngularGaussLegendreTest, Constructor) {
+  EXPECT_NO_THROW(quadrature::angular::GaussLegendre test_quadrature(n_points));
+}
+
+TEST_F(QuadratureAngularGaussLegendreTest, ConstructorBadNPoints) {
+  auto bad_n_points = test_helpers::RandomVector(5, -5, 0);
+  bad_n_points.push_back(0);
+  for (const int n_points : bad_n_points) {
+    EXPECT_ANY_THROW({
+      quadrature::angular::GaussLegendre test_quadrature(n_points);
+                     });
+  }
+}
+
+TEST_F(QuadratureAngularGaussLegendreTest, Order) {
+  EXPECT_EQ(n_points, test_quadrature_.order());
+}
+
+TEST_F(QuadratureAngularGaussLegendreTest, GenerateSet) {
+  auto set = test_quadrature_.GenerateSet();
+  EXPECT_EQ(set.size(), n_points);
+
+  double sum{0.0};
+
+  // P_1 Legendre polynomial should integrate to 0.4 over [-1, 1]
+  auto legendre = [](const double point) {
+    return 0.5 * (3*point*point - 1);
+  };
+
+  for (const auto point_pair : set) {
+    const auto point = point_pair.first.get().at(0);
+    const auto weight = point_pair.second.get();
+    sum += weight * legendre(point) * legendre(point);
+  }
+  // Multiply by 2 because points are generated from [0, 1]
+  EXPECT_NEAR(0.4, 2*sum, 1e-5);
+}
+
+} // namespace

--- a/src/quadrature/angular/tests/gauss_legendre_test.cc
+++ b/src/quadrature/angular/tests/gauss_legendre_test.cc
@@ -7,25 +7,20 @@ namespace  {
 
 using namespace bart;
 
-/* Tests for the quadrature::angular::GaussLegendre class. */
-class QuadratureAngularGaussLegendreTest : public ::testing::Test {
+/* Constructor test for quadrature::angular::GaussLegendre class */
+class QuadratureAngularGaussLegendreConstructorTest : public ::testing::Test {
  public:
-  QuadratureAngularGaussLegendreTest() : test_quadrature_(n_points) {}
-
-  // Object to be tested
-  quadrature::angular::GaussLegendre test_quadrature_;
-
   // Test parameters
   const int n_points = 4; // number of quadrature points
 };
 
 // Constructor given a valid number of points should not throw
-TEST_F(QuadratureAngularGaussLegendreTest, Constructor) {
+TEST_F(QuadratureAngularGaussLegendreConstructorTest, Constructor) {
   EXPECT_NO_THROW(quadrature::angular::GaussLegendre test_quadrature(n_points));
 }
 
 // Constructor given an invalid number of points should throw
-TEST_F(QuadratureAngularGaussLegendreTest, ConstructorBadNPoints) {
+TEST_F(QuadratureAngularGaussLegendreConstructorTest, ConstructorBadNPoints) {
   auto bad_n_points = test_helpers::RandomVector(5, -5, 0);
   bad_n_points.push_back(0);
   for (const int n_points : bad_n_points) {
@@ -34,6 +29,16 @@ TEST_F(QuadratureAngularGaussLegendreTest, ConstructorBadNPoints) {
                      });
   }
 }
+
+/* Tests for the quadrature::angular::GaussLegendre class. */
+class QuadratureAngularGaussLegendreTest
+    : public QuadratureAngularGaussLegendreConstructorTest {
+ public:
+  QuadratureAngularGaussLegendreTest() : test_quadrature_(n_points) {}
+
+  // Object to be tested
+  quadrature::angular::GaussLegendre test_quadrature_;
+};
 
 // Order getter should return number of points
 TEST_F(QuadratureAngularGaussLegendreTest, Order) {

--- a/src/quadrature/factory/quadrature_factories.cc
+++ b/src/quadrature/factory/quadrature_factories.cc
@@ -4,6 +4,7 @@
 #include "quadrature/ordinate.h"
 #include "quadrature/quadrature_point.h"
 #include "quadrature/quadrature_set.h"
+#include "quadrature/angular/gauss_legendre.h"
 #include "quadrature/angular/level_symmetric_gaussian.h"
 #include "quadrature/calculators/scalar_moment.h"
 #include "quadrature/calculators/spherical_harmonic_zeroth_moment.h"
@@ -49,7 +50,22 @@ std::shared_ptr<QuadratureGeneratorI<3>> MakeAngularQuadratureGeneratorPtr(
   if (type == AngularQuadratureSetType::kLevelSymmetricGaussian) {
     generator_ptr = std::make_shared<angular::LevelSymmetricGaussian>(order);
   } else {
-    AssertThrow(false, dealii::ExcMessage(unsupported_quadrature_error));
+    AssertThrow(false, dealii::ExcMessage(unsupported_quadrature_error))
+  }
+
+  return generator_ptr;
+}
+
+template <>
+std::shared_ptr<QuadratureGeneratorI<1>> MakeAngularQuadratureGeneratorPtr(
+    const Order order,
+    const AngularQuadratureSetType type) {
+  std::shared_ptr<QuadratureGeneratorI<1>> generator_ptr = nullptr;
+
+  if (type == AngularQuadratureSetType::kGaussLegendre) {
+    generator_ptr = std::make_shared<angular::GaussLegendre>(order.get());
+  } else {
+    AssertThrow(false, dealii::ExcMessage(unsupported_quadrature_error))
   }
 
   return generator_ptr;
@@ -61,7 +77,7 @@ std::shared_ptr<QuadratureGeneratorI<dim>> MakeAngularQuadratureGeneratorPtr(
     const AngularQuadratureSetType) {
   std::shared_ptr<QuadratureGeneratorI<dim>> generator_ptr = nullptr;
 
-  AssertThrow(false, dealii::ExcMessage(unsupported_quadrature_error));
+  AssertThrow(false, dealii::ExcMessage(unsupported_quadrature_error))
 
   return generator_ptr;
 }
@@ -88,19 +104,18 @@ std::unique_ptr<calculators::SphericalHarmonicMomentsI> MakeMomentCalculator(
       nullptr;
 
   if (impl == MomentCalculatorImpl::kScalarMoment) {
-    return_pointer = std::move(
-        std::make_unique<calculators::ScalarMoment>());
+    return_pointer = std::make_unique<calculators::ScalarMoment>();
   } else if (impl == MomentCalculatorImpl::kZerothMomentOnly) {
     AssertThrow(quadrature_set_ptr != nullptr,
                 dealii::ExcMessage("Error in factory building moment calculator, "
                                    "implementation requires quadrature set but provided"
                                    " set pointer is a nullptr"))
-    return_pointer = std::move(
+    return_pointer =
         std::make_unique<calculators::SphericalHarmonicZerothMoment<dim>>(
-            quadrature_set_ptr));
+            quadrature_set_ptr);
   }
 
-  return std::move(return_pointer);
+  return return_pointer;
 }
 
 template <int dim>
@@ -109,7 +124,7 @@ void FillQuadratureSet(
     const std::vector<std::pair<quadrature::CartesianPosition<dim>, quadrature::Weight>>& point_vector) {
 
   AssertThrow(to_fill->size() == 0,
-      dealii::ExcMessage("Error in FillQuadratureSet, set is not empty"));
+      dealii::ExcMessage("Error in FillQuadratureSet, set is not empty"))
 
   for (const auto& [position, weight] : point_vector) {
     auto ordinate_ptr = MakeOrdinatePtr<dim>();
@@ -146,9 +161,7 @@ template std::shared_ptr<QuadraturePointI<1>> MakeQuadraturePointPtr(const Quadr
 template std::shared_ptr<QuadraturePointI<2>> MakeQuadraturePointPtr(const QuadraturePointImpl);
 template std::shared_ptr<QuadraturePointI<3>> MakeQuadraturePointPtr(const QuadraturePointImpl);
 
-template std::shared_ptr<QuadratureGeneratorI<1>> MakeAngularQuadratureGeneratorPtr(const Order, const AngularQuadratureSetType);
 template std::shared_ptr<QuadratureGeneratorI<2>> MakeAngularQuadratureGeneratorPtr(const Order, const AngularQuadratureSetType);
-template std::shared_ptr<QuadratureGeneratorI<3>> MakeAngularQuadratureGeneratorPtr(const Order, const AngularQuadratureSetType);
 
 template std::shared_ptr<QuadratureSetI<1>> MakeQuadratureSetPtr(const QuadratureSetImpl);
 template std::shared_ptr<QuadratureSetI<2>> MakeQuadratureSetPtr(const QuadratureSetImpl);

--- a/src/quadrature/factory/tests/quadrature_factories_integration_test.cc
+++ b/src/quadrature/factory/tests/quadrature_factories_integration_test.cc
@@ -1,5 +1,6 @@
 #include "quadrature/factory/quadrature_factories.h"
 
+#include "quadrature/angular/gauss_legendre.h"
 #include "quadrature/angular/level_symmetric_gaussian.h"
 #include "quadrature/ordinate.h"
 #include "quadrature/quadrature_point.h"
@@ -97,6 +98,34 @@ TYPED_TEST(QuadratureFactoriesIntegrationTest,
     });
   }
 }
+
+/* Call to MakeAngularQuadratureGeneratorPtr specifying a GaussLegendre
+ * should return the correct type. If dim !=1, should throw an error */
+TYPED_TEST(QuadratureFactoriesIntegrationTest,
+           MakeAngularQuadratureGenTestGaussLegendre) {
+  constexpr int dim = this->dim;
+  const int order_value = 4;
+  if (dim == 1) {
+    auto quadrature_generator_ptr =
+        quadrature::factory::MakeAngularQuadratureGeneratorPtr<dim>(
+            quadrature::Order(order_value),
+            quadrature::AngularQuadratureSetType::kGaussLegendre);
+
+    ASSERT_NE(nullptr, quadrature_generator_ptr);
+    using ExpectedType = quadrature::angular::GaussLegendre;
+    EXPECT_NE(nullptr,
+              dynamic_cast<ExpectedType*>(quadrature_generator_ptr.get()));
+    EXPECT_EQ(quadrature_generator_ptr->order(), order_value);
+  } else {
+    EXPECT_ANY_THROW({
+                       quadrature::factory::MakeAngularQuadratureGeneratorPtr<dim>(
+                           quadrature::Order(order_value),
+                           quadrature::AngularQuadratureSetType::kGaussLegendre);
+                     });
+  }
+}
+
+
 
 /* Call to MakeQuadratureSet specifying default implementation should return
  * the correct type. */

--- a/src/quadrature/quadrature_generator_i.h
+++ b/src/quadrature/quadrature_generator_i.h
@@ -6,6 +6,8 @@
 #include <utility>
 #include <vector>
 
+#include "utility/has_description.h"
+
 namespace bart {
 
 namespace quadrature {
@@ -18,7 +20,7 @@ namespace quadrature {
  * @tparam dim spatial dimension.
  */
 template <int dim>
-class QuadratureGeneratorI {
+class QuadratureGeneratorI : public bart::utility::HasDescription {
  public:
   virtual ~QuadratureGeneratorI() = default;
   /*! \brief Generates a quadrature set.

--- a/src/quadrature/quadrature_types.h
+++ b/src/quadrature/quadrature_types.h
@@ -28,6 +28,7 @@ using QuadraturePointIndex =
 enum class AngularQuadratureSetType {
   kNone = 0,
   kLevelSymmetricGaussian = 1,
+  kGaussLegendre = 2,
 };
 
 enum class OrdinateType {

--- a/src/quadrature/tests/quadrature_generator_mock.h
+++ b/src/quadrature/tests/quadrature_generator_mock.h
@@ -12,8 +12,9 @@ namespace quadrature {
 template <int dim>
 class QuadratureGeneratorMock : QuadratureGeneratorI<dim> {
  public:
-  MOCK_CONST_METHOD0_T(GenerateSet, std::vector<std::pair<CartesianPosition<dim>, Weight>>());
-  MOCK_CONST_METHOD0_T(order, int());
+  MOCK_METHOD((std::vector<std::pair<CartesianPosition<dim>, Weight>>),
+              GenerateSet, (), (override, const));
+  MOCK_METHOD(int, order, (), (override, const));
 };
 
 } // namespace quadrature


### PR DESCRIPTION
This pull request implements **1D Quadrature** and **global mesh refinements**. The 1D angular quadrature implemented is a Gauss-Legendre quadrature, where an `n_point` quadrature creates `n` positive-mu values on the interval `[0,1]`. Therefore, a full quadrature will actually have `2*n_point` actual angles.

A solution using SAAF with 1D Quadrature of the `pu_2_0_in` benchmark is shown below:
![image](https://user-images.githubusercontent.com/11690134/85476405-1664f800-b56d-11ea-9a99-03580c0b13c7.png)