### PR TITLE
HOTFIX: Added instantiation of DiffusionUpdater with reflective BCs

### DIFF
--- a/benchmarks/sood_1999/pu_2_0_in/pu_2_0_in.input
+++ b/benchmarks/sood_1999/pu_2_0_in/pu_2_0_in.input
@@ -1,13 +1,13 @@
-set problem dimension                        = 2
+set problem dimension                        = 1
 set transport model                          = diffusion
 set number of groups                         = 2
 set do eigenvalue calculations               = true
-set have reflective boundary                 = true
-set reflective boundary names                = xmin, xmax, ymax, ymin
+set reflective boundary names                = xmin, xmax
 
-set x, y, z max values of boundary locations = 10.0, 10.0
-set number of cells for x, y, z directions   = 10, 10
+set x, y, z max values of boundary locations = 10.0
+set number of cells for x, y, z directions   = 10
 set number of materials                      = 1
+set uniform refinements                      = 2
 
 set finite element polynomial degree         = 1
 

--- a/benchmarks/sood_1999/pu_2_0_in_saaf/pu_2_0_in_saaf.input
+++ b/benchmarks/sood_1999/pu_2_0_in_saaf/pu_2_0_in_saaf.input
@@ -1,19 +1,20 @@
-set problem dimension                        = 3
+set problem dimension                        = 1
 set transport model                          = saaf
 set number of groups                         = 2
-set angular quadrature name                  = level_symmetric_gaussian
+set angular quadrature name                  = gauss_legendre
 set angular quadrature order                 = 2
 set do eigenvalue calculations               = true
 set have reflective boundary                 = true
-set reflective boundary names                = xmin, xmax, ymax, ymin
+set reflective boundary names                = xmin, xmax
 
-set x, y, z max values of boundary locations = 10.0, 10.0, 10.0
-set number of cells for x, y, z directions   = 10, 10, 10
+set x, y, z max values of boundary locations = 100.0
+set number of cells for x, y, z directions   = 10
+set uniform refinements                      = 1
 set number of materials                      = 1
 
 set finite element polynomial degree         = 1
 
-set output file name base                    = pu_2_0_in
+set output file name base                    = pu_2_0_in_saaf
 
 subsection material ID map
 set material id file name map                = 1: pu_2_0_in_pu_239.material

--- a/src/formulation/updater/diffusion_updater.cc
+++ b/src/formulation/updater/diffusion_updater.cc
@@ -18,6 +18,8 @@ DiffusionUpdater<dim>::DiffusionUpdater(
   AssertThrow(stamper_ptr_ != nullptr,
               dealii::ExcMessage("Error in constructor of DiffusionUpdater, "
                                  "stamper pointer passed is null"))
+  this->set_description("diffusion formulation updater",
+                        utility::DefaultImplementation(true));
 }
 
 template<int dim>
@@ -27,6 +29,8 @@ DiffusionUpdater<dim>::DiffusionUpdater(
     std::unordered_set<problem::Boundary> reflective_boundaries)
     : DiffusionUpdater(std::move(formulation_ptr), std::move(stamper_ptr)) {
   reflective_boundaries_ = reflective_boundaries;
+  this->set_description("diffusion formulation updater with reflective BCs",
+                        utility::DefaultImplementation(true));
 }
 template<int dim>
 void DiffusionUpdater<dim>::UpdateFixedTerms(

--- a/src/formulation/updater/diffusion_updater.cc
+++ b/src/formulation/updater/diffusion_updater.cc
@@ -9,9 +9,11 @@ namespace updater {
 template<int dim>
 DiffusionUpdater<dim>::DiffusionUpdater(
     std::unique_ptr<DiffusionFormulationType> formulation_ptr,
-    std::unique_ptr<StamperType> stamper_ptr)
+    std::unique_ptr<StamperType> stamper_ptr,
+    std::unordered_set<problem::Boundary> reflective_boundaries)
     : formulation_ptr_(std::move(formulation_ptr)),
-      stamper_ptr_(std::move(stamper_ptr)) {
+      stamper_ptr_(std::move(stamper_ptr)),
+      reflective_boundaries_(reflective_boundaries) {
   AssertThrow(formulation_ptr_ != nullptr,
               dealii::ExcMessage("Error in constructor of DiffusionUpdater, "
                                  "formulation pointer passed is null"))
@@ -20,18 +22,13 @@ DiffusionUpdater<dim>::DiffusionUpdater(
                                  "stamper pointer passed is null"))
   this->set_description("diffusion formulation updater",
                         utility::DefaultImplementation(true));
+
+  if (!reflective_boundaries_.empty()) {
+    this->set_description(this->description() + " (reflective BCs)",
+                          utility::DefaultImplementation(true));
+  }
 }
 
-template<int dim>
-DiffusionUpdater<dim>::DiffusionUpdater(
-    std::unique_ptr<DiffusionFormulationType> formulation_ptr,
-    std::unique_ptr<StamperType> stamper_ptr,
-    std::unordered_set<problem::Boundary> reflective_boundaries)
-    : DiffusionUpdater(std::move(formulation_ptr), std::move(stamper_ptr)) {
-  reflective_boundaries_ = reflective_boundaries;
-  this->set_description("diffusion formulation updater with reflective BCs",
-                        utility::DefaultImplementation(true));
-}
 template<int dim>
 void DiffusionUpdater<dim>::UpdateFixedTerms(
     system::System& to_update,

--- a/src/formulation/updater/diffusion_updater.h
+++ b/src/formulation/updater/diffusion_updater.h
@@ -12,6 +12,7 @@
 #include "formulation/updater/fission_source_updater_i.h"
 #include "quadrature/quadrature_set_i.h"
 #include "problem/parameter_types.h"
+#include "utility/has_description.h"
 
 namespace bart {
 
@@ -22,7 +23,8 @@ namespace updater {
 template <int dim>
 class DiffusionUpdater
     : public FixedUpdaterI, public ScatteringSourceUpdaterI,
-      public FissionSourceUpdaterI, public FixedSourceUpdaterI {
+      public FissionSourceUpdaterI, public FixedSourceUpdaterI,
+      public utility::HasDescription {
  public:
   using DiffusionFormulationType = formulation::scalar::DiffusionI<dim>;
   using StamperType = formulation::StamperI<dim>;

--- a/src/formulation/updater/diffusion_updater.h
+++ b/src/formulation/updater/diffusion_updater.h
@@ -29,10 +29,8 @@ class DiffusionUpdater
   using DiffusionFormulationType = formulation::scalar::DiffusionI<dim>;
   using StamperType = formulation::StamperI<dim>;
   DiffusionUpdater(std::unique_ptr<DiffusionFormulationType>,
-                   std::unique_ptr<StamperType>);
-  DiffusionUpdater(std::unique_ptr<DiffusionFormulationType>,
                    std::unique_ptr<StamperType>,
-                   std::unordered_set<problem::Boundary>);
+                   std::unordered_set<problem::Boundary> reflective_boundaries = {});
   virtual ~DiffusionUpdater() = default;
 
   void UpdateFixedTerms(

--- a/src/formulation/updater/saaf_updater.cc
+++ b/src/formulation/updater/saaf_updater.cc
@@ -23,6 +23,8 @@ SAAFUpdater<dim>::SAAFUpdater(
   AssertThrow(quadrature_set_ptr_ != nullptr,
               dealii::ExcMessage("Error in constructor of SAAFUpdater, "
                                  "quadrature set pointer passed is null"))
+  this->set_description("Self-adjoint angular flux updater",
+                        utility::DefaultImplementation(true));
 }
 
 template<int dim>
@@ -36,6 +38,9 @@ SAAFUpdater<dim>::SAAFUpdater(
                   quadrature_set_ptr) {
   reflective_boundaries_ = reflective_boundaries;
   angular_solution_ptr_map_ = angular_solution_ptr_map;
+  this->set_description("Self-adjoint angular flux updater with reflective "
+                        "boundaries",
+                        utility::DefaultImplementation(true));
 }
 
 template<int dim>

--- a/src/formulation/updater/saaf_updater.h
+++ b/src/formulation/updater/saaf_updater.h
@@ -13,6 +13,7 @@
 #include "quadrature/quadrature_set_i.h"
 #include "problem/parameter_types.h"
 #include "system/solution/solution_types.h"
+#include "utility/has_description.h"
 
 namespace bart {
 
@@ -25,7 +26,8 @@ class SAAFUpdater :
     public FixedUpdaterI,
     public BoundaryConditionsUpdaterI,
     public ScatteringSourceUpdaterI,
-    public FissionSourceUpdaterI {
+    public FissionSourceUpdaterI,
+    public utility::HasDescription {
  public:
   using Boundary = problem::Boundary;
   using EnergyGroupToAngularSolutionPtrMap = system::solution::EnergyGroupToAngularSolutionPtrMap;

--- a/src/framework/builder/framework_builder.cc
+++ b/src/framework/builder/framework_builder.cc
@@ -135,9 +135,18 @@ auto FrameworkBuilder<dim>::BuildFramework(std::string name,
         cross_sections_ptr);
     diffusion_formulation_ptr->Precalculate(domain_ptr->Cells().at(0));
     auto stamper_ptr = BuildStamper(domain_ptr);
-    updater_pointers = BuildUpdaterPointers(
-        std::move(diffusion_formulation_ptr),
-        std::move(stamper_ptr));
+
+    if (prm.HaveReflectiveBC()) {
+      updater_pointers = BuildUpdaterPointers(
+          std::move(diffusion_formulation_ptr),
+          std::move(stamper_ptr),
+          prm.ReflectiveBoundary());
+    } else {
+      updater_pointers = BuildUpdaterPointers(
+          std::move(diffusion_formulation_ptr),
+          std::move(stamper_ptr));
+    }
+    
     moment_calculator_ptr = std::move(BuildMomentCalculator());
   }
 
@@ -303,6 +312,38 @@ auto FrameworkBuilder<dim>::BuildUpdaterPointers(
   auto diffusion_updater_ptr = std::make_shared<ReturnType>(
       std::move(formulation_ptr),
       std::move(stamper_ptr));
+  ReportBuildSuccess(diffusion_updater_ptr->description());
+
+  return_struct.fixed_updater_ptr = diffusion_updater_ptr;
+  return_struct.scattering_source_updater_ptr = diffusion_updater_ptr;
+  return_struct.fission_source_updater_ptr = diffusion_updater_ptr;
+
+  return return_struct;
+}
+
+template<int dim>
+auto FrameworkBuilder<dim>::BuildUpdaterPointers(
+    std::unique_ptr<DiffusionFormulationType> formulation_ptr,
+    std::unique_ptr<StamperType> stamper_ptr,
+    const std::map<problem::Boundary, bool>& reflective_boundaries)
+-> UpdaterPointers {
+  ReportBuildingComponant("Building Diffusion Formulation updater");
+  UpdaterPointers return_struct;
+
+  std::unordered_set<problem::Boundary> reflective_boundary_set;
+
+  for (const auto boundary_pair : reflective_boundaries) {
+    if (boundary_pair.second)
+      reflective_boundary_set.insert(boundary_pair.first);
+  }
+
+  using ReturnType = formulation::updater::DiffusionUpdater<dim>;
+
+  auto diffusion_updater_ptr = std::make_shared<ReturnType>(
+      std::move(formulation_ptr),
+      std::move(stamper_ptr),
+      reflective_boundary_set);
+  ReportBuildSuccess(diffusion_updater_ptr->description());
   return_struct.fixed_updater_ptr = diffusion_updater_ptr;
   return_struct.scattering_source_updater_ptr = diffusion_updater_ptr;
   return_struct.fission_source_updater_ptr = diffusion_updater_ptr;

--- a/src/framework/builder/framework_builder.cc
+++ b/src/framework/builder/framework_builder.cc
@@ -146,7 +146,7 @@ auto FrameworkBuilder<dim>::BuildFramework(std::string name,
           std::move(diffusion_formulation_ptr),
           std::move(stamper_ptr));
     }
-    
+
     moment_calculator_ptr = std::move(BuildMomentCalculator());
   }
 
@@ -365,6 +365,7 @@ auto FrameworkBuilder<dim>::BuildUpdaterPointers(
       std::move(formulation_ptr),
       std::move(stamper_ptr),
       quadrature_set_ptr);
+  ReportBuildSuccess(saaf_updater_ptr->description());
   return_struct.fixed_updater_ptr = saaf_updater_ptr;
   return_struct.scattering_source_updater_ptr = saaf_updater_ptr;
   return_struct.fission_source_updater_ptr = saaf_updater_ptr;
@@ -400,6 +401,7 @@ auto FrameworkBuilder<dim>::BuildUpdaterPointers(
       quadrature_set_ptr,
       angular_flux_storage,
       reflective_boundary_set);
+  ReportBuildSuccess(saaf_updater_ptr->description());
 
   return_struct.fixed_updater_ptr = saaf_updater_ptr;
   return_struct.scattering_source_updater_ptr = saaf_updater_ptr;

--- a/src/framework/builder/framework_builder.cc
+++ b/src/framework/builder/framework_builder.cc
@@ -136,16 +136,10 @@ auto FrameworkBuilder<dim>::BuildFramework(std::string name,
     diffusion_formulation_ptr->Precalculate(domain_ptr->Cells().at(0));
     auto stamper_ptr = BuildStamper(domain_ptr);
 
-    if (prm.HaveReflectiveBC()) {
-      updater_pointers = BuildUpdaterPointers(
-          std::move(diffusion_formulation_ptr),
-          std::move(stamper_ptr),
-          prm.ReflectiveBoundary());
-    } else {
-      updater_pointers = BuildUpdaterPointers(
-          std::move(diffusion_formulation_ptr),
-          std::move(stamper_ptr));
-    }
+    updater_pointers = BuildUpdaterPointers(
+        std::move(diffusion_formulation_ptr),
+        std::move(stamper_ptr),
+        prm.ReflectiveBoundary());
 
     moment_calculator_ptr = std::move(BuildMomentCalculator());
   }
@@ -297,28 +291,6 @@ auto FrameworkBuilder<dim>::BuildFiniteElement(ParametersType problem_parameters
     throw;
   }
   return return_ptr;
-}
-
-template<int dim>
-auto FrameworkBuilder<dim>::BuildUpdaterPointers(
-    std::unique_ptr<DiffusionFormulationType> formulation_ptr,
-    std::unique_ptr<StamperType> stamper_ptr)
--> UpdaterPointers {
-  ReportBuildingComponant("Building Diffusion Formulation updater");
-  UpdaterPointers return_struct;
-
-  using ReturnType = formulation::updater::DiffusionUpdater<dim>;
-
-  auto diffusion_updater_ptr = std::make_shared<ReturnType>(
-      std::move(formulation_ptr),
-      std::move(stamper_ptr));
-  ReportBuildSuccess(diffusion_updater_ptr->description());
-
-  return_struct.fixed_updater_ptr = diffusion_updater_ptr;
-  return_struct.scattering_source_updater_ptr = diffusion_updater_ptr;
-  return_struct.fission_source_updater_ptr = diffusion_updater_ptr;
-
-  return return_struct;
 }
 
 template<int dim>

--- a/src/framework/builder/framework_builder.h
+++ b/src/framework/builder/framework_builder.h
@@ -111,6 +111,10 @@ class FrameworkBuilder {
       std::unique_ptr<DiffusionFormulationType>,
       std::unique_ptr<StamperType>);
   UpdaterPointers BuildUpdaterPointers(
+      std::unique_ptr<DiffusionFormulationType>,
+      std::unique_ptr<StamperType>,
+      const std::map<problem::Boundary, bool>& reflective_boundaries);
+  UpdaterPointers BuildUpdaterPointers(
       std::unique_ptr<SAAFFormulationType>,
       std::unique_ptr<StamperType>,
       const std::shared_ptr<QuadratureSetType>&);

--- a/src/framework/builder/framework_builder.h
+++ b/src/framework/builder/framework_builder.h
@@ -109,9 +109,6 @@ class FrameworkBuilder {
   std::unique_ptr<FiniteElementType> BuildFiniteElement(ParametersType);
   UpdaterPointers BuildUpdaterPointers(
       std::unique_ptr<DiffusionFormulationType>,
-      std::unique_ptr<StamperType>);
-  UpdaterPointers BuildUpdaterPointers(
-      std::unique_ptr<DiffusionFormulationType>,
       std::unique_ptr<StamperType>,
       const std::map<problem::Boundary, bool>& reflective_boundaries);
   UpdaterPointers BuildUpdaterPointers(

--- a/src/framework/builder/tests/framework_builder_integration_tests.cc
+++ b/src/framework/builder/tests/framework_builder_integration_tests.cc
@@ -247,6 +247,30 @@ TYPED_TEST(FrameworkBuilderIntegrationTest, BuildDiffusionUpdaterPointers) {
               WhenDynamicCastTo<ExpectedType*>(NotNull()));
 }
 
+TYPED_TEST(FrameworkBuilderIntegrationTest, BuildDiffusionUpdaterPointersRefl) {
+  constexpr int dim = this->dim;
+  using ExpectedType = formulation::updater::DiffusionUpdater<dim>;
+
+  auto updater_struct = this->test_builder_ptr_->BuildUpdaterPointers(
+      std::move(this->diffusion_formulation_uptr_),
+      std::move(this->stamper_uptr_),
+      this->reflective_bcs_);
+  ASSERT_THAT(updater_struct.fixed_updater_ptr.get(),
+              WhenDynamicCastTo<ExpectedType*>(NotNull()));
+  EXPECT_THAT(updater_struct.scattering_source_updater_ptr.get(),
+              WhenDynamicCastTo<ExpectedType*>(NotNull()));
+  EXPECT_THAT(updater_struct.fission_source_updater_ptr.get(),
+              WhenDynamicCastTo<ExpectedType*>(NotNull()));
+
+  auto dynamic_ptr =
+      dynamic_cast<ExpectedType*>(updater_struct.fixed_updater_ptr.get());
+  for (auto& [boundary, is_reflective] : this->reflective_bcs_ ) {
+    if (is_reflective) {
+      EXPECT_EQ(dynamic_ptr->reflective_boundaries().count(boundary), 1);
+    }
+  }
+}
+
 TYPED_TEST(FrameworkBuilderIntegrationTest, BuildSAAFUpdaterPointers) {
   constexpr int dim = this->dim;
   using ExpectedType = formulation::updater::SAAFUpdater<dim>;

--- a/src/framework/builder/tests/framework_builder_integration_tests.cc
+++ b/src/framework/builder/tests/framework_builder_integration_tests.cc
@@ -236,9 +236,18 @@ TYPED_TEST(FrameworkBuilderIntegrationTest, BuildDiffusionFormulationTest) {
 TYPED_TEST(FrameworkBuilderIntegrationTest, BuildDiffusionUpdaterPointers) {
   constexpr int dim = this->dim;
   using ExpectedType = formulation::updater::DiffusionUpdater<dim>;
+  std::map<problem::Boundary, bool> reflective_bcs{
+      {problem::Boundary::kXMin, false},
+      {problem::Boundary::kXMax, false},
+      {problem::Boundary::kYMin, false},
+      {problem::Boundary::kYMax, false},
+      {problem::Boundary::kZMin, false},
+      {problem::Boundary::kZMax, false},
+  };
   auto updater_struct = this->test_builder_ptr_->BuildUpdaterPointers(
       std::move(this->diffusion_formulation_uptr_),
-      std::move(this->stamper_uptr_));
+      std::move(this->stamper_uptr_),
+      reflective_bcs);
   EXPECT_THAT(updater_struct.fixed_updater_ptr.get(),
               WhenDynamicCastTo<ExpectedType*>(NotNull()));
   EXPECT_THAT(updater_struct.scattering_source_updater_ptr.get(),


### PR DESCRIPTION
Framework builder did not instantiate the DiffusionUpdater class with reflective boundary conditions. Closes #171 