### PR TITLE
Group solve fix

### DIFF
--- a/src/convergence/final.cc
+++ b/src/convergence/final.cc
@@ -30,6 +30,7 @@ Final<CompareType>& Final<CompareType>::SetIteration(
 
 template class Final<system::moments::MomentVector>;
 template class Final<system::moments::MomentsMap>;
+template class Final<const system::moments::MomentsMap>;
 template class Final<double>;
 
 

--- a/src/convergence/final_checker_or_n.cc
+++ b/src/convergence/final_checker_or_n.cc
@@ -55,6 +55,8 @@ template class FinalCheckerOrN<system::moments::MomentVector,
                                moments::SingleMomentCheckerI>;
 template class FinalCheckerOrN<system::moments::MomentsMap,
                                moments::MultiMomentCheckerI>;
+template class FinalCheckerOrN<const system::moments::MomentsMap,
+                               moments::MultiMomentCheckerI>;
 template class FinalCheckerOrN<double, parameters::SingleParameterChecker>;
 
 

--- a/src/framework/builder/framework_builder.cc
+++ b/src/framework/builder/framework_builder.cc
@@ -156,11 +156,6 @@ auto FrameworkBuilder<dim>::BuildFramework(std::string name,
   auto group_solution_ptr = Shared(BuildGroupSolution(n_angles));
   system::SetUpMPIAngularSolution(*group_solution_ptr, *domain_ptr);
 
-  std::unique_ptr<MomentMapConvergenceCheckerType>
-      moment_map_convergence_checker_ptr = nullptr;
-  if (n_groups > 1)
-    moment_map_convergence_checker_ptr = BuildMomentMapConvergenceChecker(1e-6, 1000);
-
   auto iterative_group_solver_ptr = BuildGroupSolveIteration(
       BuildSingleGroupSolver(),
       BuildMomentConvergenceChecker(1e-6, 10000),
@@ -168,7 +163,7 @@ auto FrameworkBuilder<dim>::BuildFramework(std::string name,
       group_solution_ptr,
       updater_pointers,
       convergence_reporter_ptr,
-      std::move(moment_map_convergence_checker_ptr));
+      BuildMomentMapConvergenceChecker(1e-6, 1000));
 
   if (need_angular_solution_storage) {
     dynamic_cast<iteration::group::GroupSolveIteration<dim>*>(

--- a/src/framework/builder/framework_builder.cc
+++ b/src/framework/builder/framework_builder.cc
@@ -10,6 +10,7 @@
 // Convergence classes
 #include "convergence/final_checker_or_n.h"
 #include "convergence/moments/single_moment_checker_l1_norm.h"
+#include "convergence/moments/multi_moment_checker_max.h"
 #include "convergence/parameters/single_parameter_checker.h"
 #include "convergence/reporter/mpi.h"
 
@@ -537,6 +538,25 @@ auto FrameworkBuilder<dim>::BuildMomentConvergenceChecker(
   auto single_checker_ptr = std::make_unique<CheckerType>(max_delta);
   auto return_ptr = std::make_unique<FinalCheckerType>(
       std::move(single_checker_ptr));
+  return_ptr->SetMaxIterations(max_iterations);
+  return return_ptr;
+}
+
+template <int dim>
+auto FrameworkBuilder<dim>::BuildMomentMapConvergenceChecker(
+    double max_delta, int max_iterations)
+-> std::unique_ptr<MomentMapConvergenceCheckerType> {
+  ReportBuildingComponant("Moment map convergence checker");
+
+  using SingleCheckerType = convergence::moments::SingleMomentCheckerL1Norm;
+  using CheckerType = convergence::moments::MultiMomentCheckerMax;
+  using FinalCheckerType = convergence::FinalCheckerOrN<
+      const system::moments::MomentsMap,
+      convergence::moments::MultiMomentCheckerI>;
+  auto checker_ptr = std::make_unique<CheckerType>(
+      std::make_unique<SingleCheckerType>(max_delta));
+  auto return_ptr = std::make_unique<FinalCheckerType>(
+      std::move(checker_ptr));
   return_ptr->SetMaxIterations(max_iterations);
   return return_ptr;
 }

--- a/src/framework/builder/framework_builder.h
+++ b/src/framework/builder/framework_builder.h
@@ -128,7 +128,8 @@ class FrameworkBuilder {
       std::unique_ptr<MomentCalculatorType>,
       const std::shared_ptr<GroupSolutionType>&,
       const UpdaterPointers& updater_ptrs,
-      const std::shared_ptr<ReporterType>&);
+      const std::shared_ptr<ReporterType>&,
+      std::unique_ptr<MomentMapConvergenceCheckerType> moment_map_convergence_checker_ptr);
   std::unique_ptr<InitializerType> BuildInitializer(
       const std::shared_ptr<formulation::updater::FixedUpdaterI>&,
       const int total_groups, const int total_angles);

--- a/src/framework/builder/framework_builder.h
+++ b/src/framework/builder/framework_builder.h
@@ -74,6 +74,7 @@ class FrameworkBuilder {
   using KEffectiveUpdaterType = eigenvalue::k_effective::K_EffectiveUpdaterI;
   using MomentCalculatorType = quadrature::calculators::SphericalHarmonicMomentsI;
   using MomentConvergenceCheckerType = convergence::FinalI<system::moments::MomentVector>;
+  using MomentMapConvergenceCheckerType = convergence::FinalI<const system::moments::MomentsMap>;
   using OuterIterationType = iteration::outer::OuterIterationI;
   using ParameterConvergenceCheckerType = convergence::FinalI<double>;
   using QuadratureSetType = quadrature::QuadratureSetI<dim>;
@@ -142,6 +143,8 @@ class FrameworkBuilder {
       std::shared_ptr<QuadratureSetType>,
       MomentCalculatorImpl implementation = MomentCalculatorImpl::kZerothMomentOnly);
   std::unique_ptr<MomentConvergenceCheckerType> BuildMomentConvergenceChecker(
+      double max_delta, int max_iterations);
+  std::unique_ptr<MomentMapConvergenceCheckerType> BuildMomentMapConvergenceChecker(
       double max_delta, int max_iterations);
   std::unique_ptr<OuterIterationType> BuildOuterIteration(
       std::unique_ptr<GroupSolveIterationType>,

--- a/src/framework/builder/tests/framework_builder_integration_tests.cc
+++ b/src/framework/builder/tests/framework_builder_integration_tests.cc
@@ -7,6 +7,7 @@
 #include "convergence/final_checker_or_n.h"
 #include "convergence/parameters/single_parameter_checker.h"
 #include "convergence/moments/single_moment_checker_i.h"
+#include "convergence/moments/multi_moment_checker_i.h"
 #include "data/cross_sections.h"
 #include "domain/finite_element/finite_element_gaussian.h"
 #include "domain/definition.h"
@@ -536,7 +537,7 @@ TYPED_TEST(FrameworkBuilderIntegrationTest, BuildConvergenceChecker) {
 
 TYPED_TEST(FrameworkBuilderIntegrationTest, BuildMomentConvergenceChecker) {
   const double max_delta = 1e-4;
-  const int max_iterations = 100;
+  const int max_iterations = 73;
 
   auto convergence_ptr =
       this->test_builder_ptr_->BuildMomentConvergenceChecker(
@@ -552,6 +553,27 @@ TYPED_TEST(FrameworkBuilderIntegrationTest, BuildMomentConvergenceChecker) {
   EXPECT_EQ(convergence_ptr->max_iterations(), max_iterations);
 
 }
+
+TYPED_TEST(FrameworkBuilderIntegrationTest, BuildMomentMapConvergenceChecker) {
+  const double max_delta = 1e-4;
+  const int max_iterations = 73;
+
+  auto convergence_ptr =
+      this->test_builder_ptr_->BuildMomentMapConvergenceChecker(
+          max_delta,
+          max_iterations);
+
+  using ExpectedType =
+  convergence::FinalCheckerOrN<const system::moments::MomentsMap,
+                               convergence::moments::MultiMomentCheckerI>;
+
+  ASSERT_THAT(convergence_ptr.get(),
+              WhenDynamicCastTo<ExpectedType*>(NotNull()));
+  EXPECT_EQ(convergence_ptr->max_iterations(), max_iterations);
+
+}
+
+
 
 TYPED_TEST(FrameworkBuilderIntegrationTest, BuildSAAFFormulationTest) {
   constexpr int dim = this->dim;

--- a/src/framework/builder/tests/framework_builder_integration_tests.cc
+++ b/src/framework/builder/tests/framework_builder_integration_tests.cc
@@ -352,7 +352,8 @@ TYPED_TEST(FrameworkBuilderIntegrationTest, BuildGroupSourceIterationTest) {
       std::move(this->moment_calculator_uptr_),
       this->group_solution_sptr_,
       updater_ptrs,
-      this->convergence_reporter_sptr_);
+      this->convergence_reporter_sptr_,
+      nullptr);
   EXPECT_THAT(source_iteration_ptr.get(),
               WhenDynamicCastTo<ExpectedType*>(NotNull()));
 }
@@ -371,7 +372,8 @@ TYPED_TEST(FrameworkBuilderIntegrationTest, BuildGroupSourceIterationWithBCUpdat
       std::move(this->moment_calculator_uptr_),
       this->group_solution_sptr_,
       updater_ptrs,
-      this->convergence_reporter_sptr_);
+      this->convergence_reporter_sptr_,
+      nullptr);
   EXPECT_THAT(source_iteration_ptr.get(),
               WhenDynamicCastTo<ExpectedType*>(NotNull()));
 }

--- a/src/iteration/group/group_solve_iteration.cc
+++ b/src/iteration/group/group_solve_iteration.cc
@@ -57,10 +57,10 @@ void GroupSolveIteration<dim>::Iterate(system::System &system) {
   if (reporter_ptr_ != nullptr)
     reporter_ptr_->Report("..Inner group iteration\n");
   convergence::Status all_group_convergence_status;
-
+  all_group_convergence_status.is_complete = true;
   do {
     for (int group = 0; group < total_groups; ++group) {
-      auto& current_moments = *system.current_moments;
+      const auto& current_moments = *system.current_moments;
       const int max_harmonic_l = current_moments.max_harmonic_l();
       for (int l = 0; l <= max_harmonic_l; ++l) {
         for (int m = -l; m <= l; ++m) {
@@ -109,8 +109,6 @@ void GroupSolveIteration<dim>::Iterate(system::System &system) {
         reporter_ptr_->Report("....All group convergence: ");
         reporter_ptr_->Report(all_group_convergence_status);
       }
-    } else {
-      all_group_convergence_status.is_complete = true;
     }
   } while(!all_group_convergence_status.is_complete);
 }

--- a/src/iteration/group/group_solve_iteration.cc
+++ b/src/iteration/group/group_solve_iteration.cc
@@ -12,12 +12,14 @@ GroupSolveIteration<dim>::GroupSolveIteration(
     std::unique_ptr<ConvergenceChecker> convergence_checker_ptr,
     std::unique_ptr<MomentCalculator> moment_calculator_ptr,
     const std::shared_ptr<GroupSolution> &group_solution_ptr,
-    const std::shared_ptr<Reporter> &reporter_ptr)
+    const std::shared_ptr<Reporter> &reporter_ptr,
+    std::unique_ptr<MomentMapConvergenceChecker> moment_map_convergence_checker_ptr)
     : group_solver_ptr_(std::move(group_solver_ptr)),
       convergence_checker_ptr_(std::move(convergence_checker_ptr)),
       moment_calculator_ptr_(std::move(moment_calculator_ptr)),
       group_solution_ptr_(group_solution_ptr),
-      reporter_ptr_(reporter_ptr) {
+      reporter_ptr_(reporter_ptr),
+      moment_map_convergence_checker_ptr_(std::move(moment_map_convergence_checker_ptr)){
 
   AssertThrow(group_solver_ptr_ != nullptr,
               dealii::ExcMessage("Group solver pointer passed to "

--- a/src/iteration/group/group_solve_iteration.cc
+++ b/src/iteration/group/group_solve_iteration.cc
@@ -50,7 +50,6 @@ void GroupSolveIteration<dim>::Iterate(system::System &system) {
     for (int l = 0; l <= max_harmonic_l; ++l) {
       for (int m = -l; m <= l; ++m) {
         previous_moments[{group, l, m}] = current_moments[{group, l, m}];
-        previous_moments_map[{group, l, m}] = previous_moments[{group, l, m}];
       }
     }
   }
@@ -60,6 +59,15 @@ void GroupSolveIteration<dim>::Iterate(system::System &system) {
   convergence::Status all_group_convergence_status;
 
   do {
+    for (int group = 0; group < total_groups; ++group) {
+      auto& current_moments = *system.current_moments;
+      const int max_harmonic_l = current_moments.max_harmonic_l();
+      for (int l = 0; l <= max_harmonic_l; ++l) {
+        for (int m = -l; m <= l; ++m) {
+          previous_moments_map[{group, l, m}] = current_moments[{group, l, m}];
+        }
+      }
+    }
     for (int group = 0; group < total_groups; ++group) {
       PerformPerGroup(system, group);
 
@@ -98,7 +106,7 @@ void GroupSolveIteration<dim>::Iterate(system::System &system) {
           moment_map_convergence_checker_ptr_->CheckFinalConvergence(
               system.current_moments->moments(), previous_moments_map);
       if (reporter_ptr_ != nullptr) {
-        reporter_ptr_->Report("....Checking all group convergence\n");
+        reporter_ptr_->Report("....All group convergence: ");
         reporter_ptr_->Report(all_group_convergence_status);
       }
     } else {

--- a/src/iteration/group/group_solve_iteration.h
+++ b/src/iteration/group/group_solve_iteration.h
@@ -23,6 +23,7 @@ class GroupSolveIteration : public GroupSolveIterationI {
  public:
   using GroupSolver = solver::group::SingleGroupSolverI;
   using ConvergenceChecker = convergence::FinalI<system::moments::MomentVector>;
+  using MomentMapConvergenceChecker = convergence::FinalI<system::moments::MomentsMap>;
   using MomentCalculator = quadrature::calculators::SphericalHarmonicMomentsI;
   using GroupSolution = system::solution::MPIGroupAngularSolutionI;
   using Reporter = convergence::reporter::MpiI;
@@ -33,7 +34,8 @@ class GroupSolveIteration : public GroupSolveIterationI {
       std::unique_ptr<ConvergenceChecker> convergence_checker_ptr,
       std::unique_ptr<MomentCalculator> moment_calculator_ptr,
       const std::shared_ptr<GroupSolution> &group_solution_ptr,
-      const std::shared_ptr<Reporter> &reporter_ptr = nullptr);
+      const std::shared_ptr<Reporter> &reporter_ptr = nullptr,
+      std::unique_ptr<MomentMapConvergenceChecker> moment_map_convergence_checker_ptr = nullptr);
 
   GroupSolveIteration& UpdateThisAngularSolutionMap(
       EnergyGroupToAngularSolutionPtrMap& to_update) {
@@ -66,6 +68,10 @@ class GroupSolveIteration : public GroupSolveIterationI {
     return moment_calculator_ptr_.get();
   }
 
+  MomentMapConvergenceChecker* moment_map_convergence_checker_ptr() const {
+    return moment_map_convergence_checker_ptr_.get();
+  }
+
   std::shared_ptr<GroupSolution> group_solution_ptr() const {
     return group_solution_ptr_;
   }
@@ -92,6 +98,8 @@ class GroupSolveIteration : public GroupSolveIterationI {
   std::unique_ptr<MomentCalculator> moment_calculator_ptr_ = nullptr;
   std::shared_ptr<GroupSolution> group_solution_ptr_ = nullptr;
   std::shared_ptr<Reporter> reporter_ptr_ = nullptr;
+  std::unique_ptr<MomentMapConvergenceChecker>
+      moment_map_convergence_checker_ptr_ = nullptr;
   bool is_storing_angular_solution_ = false;
   EnergyGroupToAngularSolutionPtrMap angular_solution_ptr_map_;
 };

--- a/src/iteration/group/group_solve_iteration.h
+++ b/src/iteration/group/group_solve_iteration.h
@@ -23,7 +23,7 @@ class GroupSolveIteration : public GroupSolveIterationI {
  public:
   using GroupSolver = solver::group::SingleGroupSolverI;
   using ConvergenceChecker = convergence::FinalI<system::moments::MomentVector>;
-  using MomentMapConvergenceChecker = convergence::FinalI<system::moments::MomentsMap>;
+  using MomentMapConvergenceChecker = convergence::FinalI<const system::moments::MomentsMap>;
   using MomentCalculator = quadrature::calculators::SphericalHarmonicMomentsI;
   using GroupSolution = system::solution::MPIGroupAngularSolutionI;
   using Reporter = convergence::reporter::MpiI;

--- a/src/iteration/group/group_source_iteration.cc
+++ b/src/iteration/group/group_source_iteration.cc
@@ -13,12 +13,14 @@ GroupSourceIteration<dim>::GroupSourceIteration(
     std::unique_ptr<MomentCalculator> moment_calculator_ptr,
     const std::shared_ptr<GroupSolution> &group_solution_ptr,
     const std::shared_ptr<SourceUpdater> &source_updater_ptr,
-    const std::shared_ptr<Reporter> &reporter_ptr)
+    const std::shared_ptr<Reporter> &reporter_ptr,
+    std::unique_ptr<MomentMapConvergenceChecker> moment_map_convergence_checker_ptr)
     : GroupSolveIteration<dim>(std::move(group_solver_ptr),
         std::move(convergence_checker_ptr),
         std::move(moment_calculator_ptr),
         group_solution_ptr,
-        reporter_ptr) {
+        reporter_ptr,
+        std::move(moment_map_convergence_checker_ptr)) {
   source_updater_ptr_ = source_updater_ptr;
   AssertThrow(source_updater_ptr_ != nullptr,
               dealii::ExcMessage("Source updater pointer passed to "
@@ -35,14 +37,16 @@ GroupSourceIteration<dim>::GroupSourceIteration(
     const std::shared_ptr<GroupSolution> &group_solution_ptr,
     const std::shared_ptr<SourceUpdater> &source_updater_ptr,
     const std::shared_ptr<BoundaryConditionsUpdater> &boundary_condition_updater_ptr,
-    const std::shared_ptr<Reporter> &reporter_ptr)
+    const std::shared_ptr<Reporter> &reporter_ptr,
+    std::unique_ptr<MomentMapConvergenceChecker> moment_map_convergence_checker_ptr)
     : GroupSourceIteration<dim>::GroupSourceIteration(
         std::move(group_solver_ptr),
         std::move(convergence_checker_ptr),
         std::move(moment_calculator_ptr),
         group_solution_ptr,
         source_updater_ptr,
-        reporter_ptr) {
+        reporter_ptr,
+        std::move(moment_map_convergence_checker_ptr)) {
   boundary_condition_updater_ptr_ = boundary_condition_updater_ptr;
   AssertThrow(boundary_condition_updater_ptr_ != nullptr,
       dealii::ExcMessage("Boundary conditions updater pointer passed to "

--- a/src/iteration/group/group_source_iteration.h
+++ b/src/iteration/group/group_source_iteration.h
@@ -17,6 +17,7 @@ class GroupSourceIteration : public GroupSolveIteration<dim> {
   using typename GroupSolveIteration<dim>::GroupSolver;
   using typename GroupSolveIteration<dim>::ConvergenceChecker;
   using typename GroupSolveIteration<dim>::MomentCalculator;
+  using typename GroupSolveIteration<dim>::MomentMapConvergenceChecker;
   using typename GroupSolveIteration<dim>::GroupSolution;
   using typename GroupSolveIteration<dim>::Reporter;
 
@@ -29,7 +30,9 @@ class GroupSourceIteration : public GroupSolveIteration<dim> {
       std::unique_ptr<MomentCalculator> moment_calculator_ptr,
       const std::shared_ptr<GroupSolution> &group_solution_ptr,
       const std::shared_ptr<SourceUpdater> &source_updater_ptr,
-      const std::shared_ptr<Reporter> &reporter_ptr = nullptr);
+      const std::shared_ptr<Reporter> &reporter_ptr = nullptr,
+      std::unique_ptr<MomentMapConvergenceChecker>
+          moment_map_convergence_checker_ptr = nullptr);
   GroupSourceIteration(
       std::unique_ptr<GroupSolver> group_solver_ptr,
       std::unique_ptr<ConvergenceChecker> convergence_checker_ptr,
@@ -37,7 +40,9 @@ class GroupSourceIteration : public GroupSolveIteration<dim> {
       const std::shared_ptr<GroupSolution> &group_solution_ptr,
       const std::shared_ptr<SourceUpdater> &source_updater_ptr,
       const std::shared_ptr<BoundaryConditionsUpdater>& boundary_condition_updater_ptr,
-      const std::shared_ptr<Reporter> &reporter_ptr = nullptr);
+      const std::shared_ptr<Reporter> &reporter_ptr = nullptr,
+      std::unique_ptr<MomentMapConvergenceChecker>
+      moment_map_convergence_checker_ptr = nullptr);
   virtual ~GroupSourceIteration() = default;
 
   BoundaryConditionsUpdater* boundary_conditions_updater_ptr() const {

--- a/src/iteration/group/tests/group_solve_iteration_mock.h
+++ b/src/iteration/group/tests/group_solve_iteration_mock.h
@@ -13,7 +13,7 @@ namespace group {
 
 class GroupSolveIterationMock : public GroupSolveIterationI {
  public:
-  MOCK_METHOD1(Iterate, void(system::System &system));
+  MOCK_METHOD(void, Iterate, (system::System &system), (override));
 };
 
 } // namespace group

--- a/src/iteration/group/tests/group_source_iteration_test.cc
+++ b/src/iteration/group/tests/group_source_iteration_test.cc
@@ -56,10 +56,6 @@ class IterationGroupSourceIterationTest : public ::testing::Test {
   std::unique_ptr<TestGroupIterator> test_iterator_ptr_;
 
   // Mock dependency objects
-  std::unique_ptr<GroupSolver> single_group_solver_ptr_;
-  std::unique_ptr<ConvergenceChecker> convergence_checker_ptr_;
-  std::unique_ptr<MomentCalculator> moment_calculator_ptr_;
-  std::unique_ptr<MomentMapConvergenceChecker> moment_map_convergence_checker_ptr_;
   std::shared_ptr<GroupSolution> group_solution_ptr_;
   std::shared_ptr<BoundaryConditionsUpdater> boundary_conditions_updater_ptr_;
   std::shared_ptr<SourceUpdater> source_updater_ptr_;
@@ -74,7 +70,6 @@ class IterationGroupSourceIterationTest : public ::testing::Test {
   ConvergenceChecker* convergence_checker_obs_ptr_ = nullptr;
   MomentCalculator* moment_calculator_obs_ptr_ = nullptr;
   MomentMapConvergenceChecker* moment_map_convergence_checker_obs_ptr_ = nullptr;
-  SourceUpdater* source_updater_obs_ptr_ = nullptr;
   Moments* moments_obs_ptr_ = nullptr;
 
   void SetUp() override;
@@ -84,19 +79,19 @@ TYPED_TEST_CASE(IterationGroupSourceIterationTest, bart::testing::AllDimensions)
 
 template <typename DimensionWrapper>
 void IterationGroupSourceIterationTest<DimensionWrapper>::SetUp() {
-  single_group_solver_ptr_ = std::make_unique<GroupSolver>();
+  auto single_group_solver_ptr_ = std::make_unique<GroupSolver>();
   single_group_obs_ptr_ = single_group_solver_ptr_.get();
-  convergence_checker_ptr_ = std::make_unique<ConvergenceChecker>();
+  auto convergence_checker_ptr_ = std::make_unique<ConvergenceChecker>();
   convergence_checker_obs_ptr_ = convergence_checker_ptr_.get();
-  moment_calculator_ptr_ = std::make_unique<MomentCalculator>();
+  auto moment_calculator_ptr_ = std::make_unique<MomentCalculator>();
   moment_calculator_obs_ptr_ = moment_calculator_ptr_.get();
-  moment_map_convergence_checker_ptr_ =
+  auto moment_map_convergence_checker_ptr_ =
       std::make_unique<MomentMapConvergenceChecker>();
   moment_map_convergence_checker_obs_ptr_ = moment_map_convergence_checker_ptr_.get();
+
   group_solution_ptr_ = std::make_shared<GroupSolution>();
   boundary_conditions_updater_ptr_ = std::make_shared<BoundaryConditionsUpdater>();
   source_updater_ptr_ = std::make_shared<SourceUpdater>();
-  source_updater_obs_ptr_ = source_updater_ptr_.get();
   reporter_ptr_ = std::make_shared<Reporter>();
 
   test_system.current_moments = std::make_unique<Moments>();
@@ -366,7 +361,7 @@ TYPED_TEST(IterationGroupSourceSystemSolvingTest, Iterate) {
         .Times(AtLeast(1))
         .WillRepeatedly(Solve(this));
     for (int angle = 0; angle < this->total_angles; ++angle) {
-      EXPECT_CALL(*this->source_updater_obs_ptr_, UpdateScatteringSource(
+      EXPECT_CALL(*this->source_updater_ptr_, UpdateScatteringSource(
           Ref(this->test_system),
           bart::system::EnergyGroup(group),
           quadrature::QuadraturePointIndex(angle)))

--- a/src/iteration/group/tests/group_source_iteration_test.cc
+++ b/src/iteration/group/tests/group_source_iteration_test.cc
@@ -354,6 +354,10 @@ TYPED_TEST(IterationGroupSourceSystemSolvingTest, Iterate) {
         EXPECT_CALL(*this->moments_obs_ptr_, BracketOp(index))
             .Times(AtLeast(1))
             .WillRepeatedly(ReturnRef(current_moments.at(index)));
+        const auto& const_mock_current_moments = *this->moments_obs_ptr_;
+        EXPECT_CALL(const_mock_current_moments, BracketOp(index))
+            .Times(AtLeast(1))
+            .WillRepeatedly(ReturnRef(current_moments.at(index)));
         EXPECT_CALL(*this->previous_moments_obs_ptr_, BracketOp(index))
             .Times(AtLeast(1))
             .WillRepeatedly(ReturnRef(previous_moments.at(index)));

--- a/src/system/moments/tests/spherical_harmonic_mock.h
+++ b/src/system/moments/tests/spherical_harmonic_mock.h
@@ -13,18 +13,18 @@ namespace moments {
 
 class SphericalHarmonicMock : public SphericalHarmonicI {
  public:
-  MOCK_CONST_METHOD0(total_groups, int());
-  MOCK_CONST_METHOD0(max_harmonic_l, int());
-  MOCK_CONST_METHOD0(moments, const MomentsMap&());
-  MOCK_CONST_METHOD1(GetMoment, const MomentVector&(const MomentIndex));
-  MOCK_CONST_METHOD1(BracketOp, const MomentVector&(const MomentIndex));
-  MOCK_METHOD1(BracketOp, MomentVector&(const MomentIndex));
+  MOCK_METHOD(int, total_groups, (), (const, override));
+  MOCK_METHOD(int, max_harmonic_l, (), (const, override));
+  MOCK_METHOD(const MomentsMap&, moments, (), (const, override));
+  MOCK_METHOD(const MomentVector&, GetMoment, (const MomentIndex), (const, override));
   MOCK_METHOD(MomentsMap::const_iterator, cbegin, (), (const, override));
   MOCK_METHOD(MomentsMap::iterator, begin, (), (override));
   MOCK_METHOD(MomentsMap::const_iterator, cend, (), (const, override));
   MOCK_METHOD(MomentsMap::iterator, end, (), (override));
 
-
+  MOCK_METHOD(const MomentVector&, BracketOp, (const MomentIndex), (const));
+  MOCK_METHOD(MomentVector&, BracketOp, (const MomentIndex));
+  
   const MomentVector& operator[](const MomentIndex index) const override {
     return BracketOp(index);
   };


### PR DESCRIPTION
This update includes the following major updates:
- Group solve iterations now verifies that _all_ group moments have converged before completing when `n_groups > 1`. Closes #181 

Bug updates:
- Group solve iteration test updated to prevent always going to max iterations, added check to verify max iterations isn't reached. Closes #180 

Minor updates:
- Updated GroupSolveIterationMock to new mock format, see #151 