### PR TITLE
Fixed source solver

### DIFF
--- a/src/formulation/angular/self_adjoint_angular_flux.cc
+++ b/src/formulation/angular/self_adjoint_angular_flux.cc
@@ -224,10 +224,14 @@ void SelfAdjointAngularFlux<dim>::FillCellFixedSourceTerm(
     const system::EnergyGroup group_number) {
   VerifyInitialized(__FUNCTION__);
   ValidateVectorSizeAndSetCell(cell_ptr, to_fill, __FUNCTION__);
-
+  double q_per_ster = 0;
   const int material_id = cell_ptr->material_id();
-  const double q_per_ster =
-      cross_sections_ptr_->q_per_ster.at(material_id).at(group_number.get());
+  try {
+    q_per_ster =
+        cross_sections_ptr_->q_per_ster.at(material_id).at(group_number.get());
+  } catch (std::out_of_range&) {
+    return;
+  }
 
   std::vector<double> fixed_source(cell_degrees_of_freedom_);
   std::fill(fixed_source.begin(), fixed_source.end(), q_per_ster);

--- a/src/formulation/scalar/diffusion.cc
+++ b/src/formulation/scalar/diffusion.cc
@@ -118,8 +118,12 @@ void Diffusion<dim>::FillCellFixedSource(Vector& to_fill,
 
   finite_element_->SetCell(cell_ptr);
   int material_id = cell_ptr->material_id();
-
-  const double q{cross_sections_->q.at(material_id)[group]};
+  double q = 0;
+  try {
+    q = cross_sections_->q.at(material_id).at(group);
+  } catch (std::exception&) {
+    return;
+  }
   std::vector<double> cell_fixed_source(cell_quadrature_points_, q);
 
   for (int q = 0; q < cell_quadrature_points_; ++q) {

--- a/src/formulation/updater/tests/diffusion_updater_test.cc
+++ b/src/formulation/updater/tests/diffusion_updater_test.cc
@@ -118,12 +118,16 @@ TYPED_TEST(FormulationUpdaterDiffusionTest, UpdateFixedTermTest) {
 
   EXPECT_CALL(*this->mock_lhs_obs_ptr_, GetFixedTermPtr(scalar_index))
       .WillOnce(DoDefault());
+  EXPECT_CALL(*this->mock_rhs_obs_ptr_, GetFixedTermPtr(scalar_index))
+      .WillOnce(DoDefault());
 
   for (auto& cell : this->cells_) {
     EXPECT_CALL(*this->formulation_obs_ptr_,
                 FillCellStreamingTerm(_, cell, this->group_number));
     EXPECT_CALL(*this->formulation_obs_ptr_,
                 FillCellCollisionTerm(_, cell, this->group_number));
+    EXPECT_CALL(*this->formulation_obs_ptr_,
+                FillCellFixedSource(_, cell, this->group_number));
     if (cell->at_boundary()) {
       int faces_per_cell = dealii::GeometryInfo<this->dim>::faces_per_cell;
       for (int face = 0; face < faces_per_cell; ++face) {
@@ -150,10 +154,15 @@ TYPED_TEST(FormulationUpdaterDiffusionTest, UpdateFixedTermTest) {
   EXPECT_CALL(*this->stamper_obs_ptr_,
       StampBoundaryMatrix(Ref(*this->matrix_to_stamp), _))
       .WillOnce(DoDefault());
+  EXPECT_CALL(*this->stamper_obs_ptr_,
+      StampVector(Ref(*this->vector_to_stamp), _))
+      .WillOnce(DoDefault());
 
   this->test_updater_ptr_->UpdateFixedTerms(this->test_system_, group_number, angle_index);
   EXPECT_TRUE(test_helpers::CompareMPIMatrices(this->expected_result,
                                                *this->matrix_to_stamp));
+  EXPECT_TRUE(test_helpers::CompareMPIVectors(this->expected_vector_result,
+                                              *this->vector_to_stamp));
 }
 
 // ====== UpdateScatteringSource TESTS =========================================

--- a/src/formulation/updater/tests/saaf_updater_test.cc
+++ b/src/formulation/updater/tests/saaf_updater_test.cc
@@ -264,6 +264,8 @@ TYPED_TEST(FormulationUpdaterSAAFTest, UpdateFixedTermsTest) {
 
   EXPECT_CALL(*this->mock_lhs_obs_ptr_, GetFixedTermPtr(this->index))
       .WillOnce(DoDefault());
+  EXPECT_CALL(*this->mock_rhs_obs_ptr_, GetFixedTermPtr(this->index))
+      .WillOnce(DoDefault());
   EXPECT_CALL(*this->quadrature_set_ptr_, GetQuadraturePoint(quad_index))
       .WillOnce(Return(quadrature_point_ptr_));
 
@@ -273,6 +275,8 @@ TYPED_TEST(FormulationUpdaterSAAFTest, UpdateFixedTermsTest) {
                                       cell,
                                       quadrature_point_ptr_,
                                       group_number));
+    EXPECT_CALL(*this->formulation_obs_ptr_,
+        FillCellFixedSourceTerm(_, cell, quadrature_point_ptr_, group_number));
     EXPECT_CALL(*this->formulation_obs_ptr_,
                 FillCellCollisionTerm(_, cell, group_number));
     int faces_per_cell = dealii::GeometryInfo<dim>::faces_per_cell;
@@ -297,10 +301,16 @@ TYPED_TEST(FormulationUpdaterSAAFTest, UpdateFixedTermsTest) {
       StampBoundaryMatrix(Ref(*this->matrix_to_stamp),_))
       .WillOnce(DoDefault());
 
+  EXPECT_CALL(*this->stamper_obs_ptr_,
+      StampVector(Ref(*this->vector_to_stamp),_))
+      .WillOnce(DoDefault());
+
   this->test_updater_ptr->UpdateFixedTerms(this->test_system_, group_number,
                                            quad_index);
   EXPECT_TRUE(test_helpers::CompareMPIMatrices(this->expected_result,
                                                *this->matrix_to_stamp));
+  EXPECT_TRUE(test_helpers::CompareMPIVectors(this->expected_vector_result,
+                                              *this->vector_to_stamp));
 }
 
 TYPED_TEST(FormulationUpdaterSAAFTest, UpdateScatteringSourceTest) {

--- a/src/framework/builder/framework_builder.h
+++ b/src/framework/builder/framework_builder.h
@@ -150,6 +150,10 @@ class FrameworkBuilder {
   std::unique_ptr<OuterIterationType> BuildOuterIteration(
       std::unique_ptr<GroupSolveIterationType>,
       std::unique_ptr<ParameterConvergenceCheckerType>,
+      const std::shared_ptr<ReporterType>&);
+  std::unique_ptr<OuterIterationType> BuildOuterIteration(
+      std::unique_ptr<GroupSolveIterationType>,
+      std::unique_ptr<ParameterConvergenceCheckerType>,
       std::unique_ptr<KEffectiveUpdaterType>,
       const std::shared_ptr<FissionSourceUpdaterType>&,
       const std::shared_ptr<ReporterType>&);

--- a/src/framework/builder/tests/framework_builder_integration_tests.cc
+++ b/src/framework/builder/tests/framework_builder_integration_tests.cc
@@ -18,6 +18,7 @@
 #include "formulation/updater/diffusion_updater.h"
 #include "formulation/stamper.h"
 #include "iteration/outer/outer_power_iteration.h"
+#include "iteration/outer/outer_fixed_source_iteration.h"
 #include "quadrature/calculators/scalar_moment.h"
 #include "quadrature/calculators/spherical_harmonic_zeroth_moment.h"
 #include "quadrature/quadrature_set.h"
@@ -455,6 +456,18 @@ TYPED_TEST(FrameworkBuilderIntegrationTest, BuildPowerIterationTest) {
   ASSERT_THAT(power_iteration_ptr.get(),
                   WhenDynamicCastTo<ExpectedType*>(NotNull()));
 }
+
+TYPED_TEST(FrameworkBuilderIntegrationTest, BuildFixedSourceIterationTest) {
+  auto power_iteration_ptr = this->test_builder_ptr_->BuildOuterIteration(
+      std::move(this->group_solve_iteration_uptr_),
+      std::move(this->parameter_convergence_checker_uptr_),
+      this->convergence_reporter_sptr_);
+  using ExpectedType = iteration::outer::OuterFixedSourceIteration;
+  ASSERT_THAT(power_iteration_ptr.get(),
+              WhenDynamicCastTo<ExpectedType*>(NotNull()));
+}
+
+
 
 TYPED_TEST(FrameworkBuilderIntegrationTest, BuildGaussLegendreQuadratureSet) {
   constexpr int dim = this->dim;

--- a/src/iteration/outer/outer_fixed_source_iteration.cc
+++ b/src/iteration/outer/outer_fixed_source_iteration.cc
@@ -12,7 +12,10 @@ OuterFixedSourceIteration::OuterFixedSourceIteration(
     const std::shared_ptr<Reporter>& reporter_ptr)
     : OuterIteration<double>(std::move(group_iterator_ptr),
                              std::move(convergence_checker_ptr),
-                             reporter_ptr) {}
+                             reporter_ptr) {
+  this->set_description("outer fixed source iteration",
+                        utility::DefaultImplementation(true));
+}
 
 convergence::Status OuterFixedSourceIteration::CheckConvergence(system::System &system) {
   convergence::Status return_status;

--- a/src/iteration/outer/outer_fixed_source_iteration.cc
+++ b/src/iteration/outer/outer_fixed_source_iteration.cc
@@ -14,6 +14,13 @@ OuterFixedSourceIteration::OuterFixedSourceIteration(
                              std::move(convergence_checker_ptr),
                              reporter_ptr) {}
 
+convergence::Status OuterFixedSourceIteration::CheckConvergence(system::System &system) {
+  convergence::Status return_status;
+  return_status.is_complete = true;
+  return_status.delta = std::nullopt;
+  return return_status;
+}
+
 } // namespace out
 
 } // namespace iteration

--- a/src/iteration/outer/outer_fixed_source_iteration.cc
+++ b/src/iteration/outer/outer_fixed_source_iteration.cc
@@ -1,0 +1,21 @@
+#include "iteration/outer/outer_fixed_source_iteration.h"
+
+namespace bart {
+
+namespace iteration {
+
+namespace outer {
+
+OuterFixedSourceIteration::OuterFixedSourceIteration(
+    std::unique_ptr<GroupIterator> group_iterator_ptr,
+    std::unique_ptr<ConvergenceChecker> convergence_checker_ptr,
+    const std::shared_ptr<Reporter>& reporter_ptr)
+    : OuterIteration<double>(std::move(group_iterator_ptr),
+                             std::move(convergence_checker_ptr),
+                             reporter_ptr) {}
+
+} // namespace out
+
+} // namespace iteration
+
+} // namespace bart

--- a/src/iteration/outer/outer_fixed_source_iteration.h
+++ b/src/iteration/outer/outer_fixed_source_iteration.h
@@ -20,14 +20,10 @@ class OuterFixedSourceIteration : public OuterIteration<double> {
       std::unique_ptr<ConvergenceChecker> convergence_checker_ptr,
       const std::shared_ptr<Reporter>& reporter_ptr);
   virtual ~OuterFixedSourceIteration() = default;
-  convergence::Status CheckConvergence(system::System &system) override {
-    return convergence::Status();
-  }
-  void UpdateSystem(system::System &system,
-                    const int group,
-                    const int angle) override {
-
-  }
+  convergence::Status CheckConvergence(system::System &system) override;
+  void UpdateSystem(system::System &/*system*/,
+                    const int /*group*/,
+                    const int /*angle*/) override {}
 };
 
 } // namespace outer

--- a/src/iteration/outer/outer_fixed_source_iteration.h
+++ b/src/iteration/outer/outer_fixed_source_iteration.h
@@ -1,0 +1,39 @@
+#ifndef BART_SRC_ITERATION_OUTER_OUTER_FIXED_SOURCE_ITERATION_H_
+#define BART_SRC_ITERATION_OUTER_OUTER_FIXED_SOURCE_ITERATION_H_
+
+#include "iteration/outer/outer_iteration.h"
+
+namespace bart {
+
+namespace iteration {
+
+namespace outer {
+
+class OuterFixedSourceIteration : public OuterIteration<double> {
+ public:
+  using typename OuterIteration<double>::GroupIterator;
+  using typename OuterIteration<double>::ConvergenceChecker;
+  using typename OuterIteration<double>::Reporter;
+
+  OuterFixedSourceIteration(
+      std::unique_ptr<GroupIterator> group_iterator_ptr,
+      std::unique_ptr<ConvergenceChecker> convergence_checker_ptr,
+      const std::shared_ptr<Reporter>& reporter_ptr);
+  virtual ~OuterFixedSourceIteration() = default;
+  convergence::Status CheckConvergence(system::System &system) override {
+    return convergence::Status();
+  }
+  void UpdateSystem(system::System &system,
+                    const int group,
+                    const int angle) override {
+
+  }
+};
+
+} // namespace outer
+
+} // namespace iteration
+
+} // namespace bart
+
+#endif //BART_SRC_ITERATION_OUTER_OUTER_FIXED_SOURCE_ITERATION_H_

--- a/src/iteration/outer/outer_iteration_i.h
+++ b/src/iteration/outer/outer_iteration_i.h
@@ -3,6 +3,8 @@
 
 #include <vector>
 
+#include "utility/has_description.h"
+
 namespace bart {
 
 namespace system {
@@ -12,7 +14,7 @@ namespace iteration {
 
 namespace outer {
 
-class OuterIterationI {
+class OuterIterationI : public utility::HasDescription {
  public:
   virtual ~OuterIterationI() = default;
   virtual void IterateToConvergence(system::System &system) = 0;

--- a/src/iteration/outer/outer_power_iteration.cc
+++ b/src/iteration/outer/outer_power_iteration.cc
@@ -25,6 +25,8 @@ OuterPowerIteration::OuterPowerIteration(
   AssertThrow(source_updater_ptr_ != nullptr,
               dealii::ExcMessage("Source updater pointer passed to OuterIteration "
                                  "constructor is null"));
+  this->set_description("outer power iteration",
+                        utility::DefaultImplementation(true));
 }
 
 convergence::Status OuterPowerIteration::CheckConvergence(system::System &system) {

--- a/src/iteration/outer/tests/outer_fixed_source_iteration_test.cc
+++ b/src/iteration/outer/tests/outer_fixed_source_iteration_test.cc
@@ -1,0 +1,57 @@
+#include "iteration/outer/outer_fixed_source_iteration.h"
+
+#include "test_helpers/gmock_wrapper.h"
+
+#include "iteration/group/tests/group_solve_iteration_mock.h"
+#include "convergence/tests/final_checker_mock.h"
+#include "convergence/reporter/tests/mpi_mock.h"
+
+namespace  {
+
+using namespace bart;
+
+class IterationOuterDummyIterationTest : public ::testing::Test {
+ public:
+  using TestIterationType = iteration::outer::OuterFixedSourceIteration;
+  // Dependency types
+  using GroupIteratorType = iteration::group::GroupSolveIterationMock;
+  using ConvergenceCheckerType = typename convergence::FinalCheckerMock<double>;
+  using ReporterType = convergence::reporter::MpiMock;
+
+  // Test object
+  std::unique_ptr<TestIterationType> test_iterator = nullptr;
+
+  // Dependencies
+  std::shared_ptr<ReporterType> reporter_mock_ptr_;
+
+  // Observation pointers
+  GroupIteratorType* group_iterator_mock_obs_ptr_;
+  ConvergenceCheckerType* convergence_checker_mock_obs_ptr_;
+
+  void SetUp() override;
+};
+
+void IterationOuterDummyIterationTest::SetUp() {
+  reporter_mock_ptr_ = std::make_shared<ReporterType>();
+  auto group_iterator_ptr = std::make_unique<GroupIteratorType>();
+  group_iterator_mock_obs_ptr_ = group_iterator_ptr.get();
+  auto convergence_checker_ptr = std::make_unique<ConvergenceCheckerType>();
+  convergence_checker_mock_obs_ptr_ = convergence_checker_ptr.get();
+
+  test_iterator = std::make_unique<TestIterationType>(
+      std::move(group_iterator_ptr),
+      std::move(convergence_checker_ptr),
+      reporter_mock_ptr_);
+}
+
+TEST_F(IterationOuterDummyIterationTest, Constructor) {
+  EXPECT_NO_THROW({
+    TestIterationType test_iterator(
+        std::make_unique<GroupIteratorType>(),
+        std::make_unique<ConvergenceCheckerType>(),
+        reporter_mock_ptr_
+        );
+  });
+}
+
+} // namespace

--- a/src/iteration/outer/tests/outer_fixed_source_iteration_test.cc
+++ b/src/iteration/outer/tests/outer_fixed_source_iteration_test.cc
@@ -9,8 +9,9 @@
 namespace  {
 
 using namespace bart;
+using ::testing::A, ::testing::Ref;
 
-class IterationOuterDummyIterationTest : public ::testing::Test {
+class IterationOuterFixedSourceIterationTest : public ::testing::Test {
  public:
   using TestIterationType = iteration::outer::OuterFixedSourceIteration;
   // Dependency types
@@ -28,10 +29,13 @@ class IterationOuterDummyIterationTest : public ::testing::Test {
   GroupIteratorType* group_iterator_mock_obs_ptr_;
   ConvergenceCheckerType* convergence_checker_mock_obs_ptr_;
 
+  // Test parameters and objects
+  bart::system::System test_system;
+
   void SetUp() override;
 };
 
-void IterationOuterDummyIterationTest::SetUp() {
+void IterationOuterFixedSourceIterationTest::SetUp() {
   reporter_mock_ptr_ = std::make_shared<ReporterType>();
   auto group_iterator_ptr = std::make_unique<GroupIteratorType>();
   group_iterator_mock_obs_ptr_ = group_iterator_ptr.get();
@@ -44,7 +48,7 @@ void IterationOuterDummyIterationTest::SetUp() {
       reporter_mock_ptr_);
 }
 
-TEST_F(IterationOuterDummyIterationTest, Constructor) {
+TEST_F(IterationOuterFixedSourceIterationTest, Constructor) {
   EXPECT_NO_THROW({
     TestIterationType test_iterator(
         std::make_unique<GroupIteratorType>(),
@@ -52,6 +56,19 @@ TEST_F(IterationOuterDummyIterationTest, Constructor) {
         reporter_mock_ptr_
         );
   });
+}
+
+TEST_F(IterationOuterFixedSourceIterationTest, Iterate) {
+  EXPECT_CALL(*group_iterator_mock_obs_ptr_, Iterate(Ref(test_system)))
+      .Times(1);
+  EXPECT_CALL(*reporter_mock_ptr_, Report(A<const convergence::Status&>()))
+      .Times(1);
+  EXPECT_CALL(*this->reporter_mock_ptr_, Report(A<const std::string&>()))
+      .Times(1);
+
+  test_iterator->IterateToConvergence(test_system);
+  auto iteration_errors = test_iterator->iteration_error();
+  ASSERT_EQ(iteration_errors.size(), 0);
 }
 
 } // namespace


### PR DESCRIPTION
This adds a fixed source outer iteration solver. This iteration is used if `set do eigenvalue calculations` is set to `false`. In the future there is probably a smarter way to do this to include eigenvalue fixed-source calculations. Closes #170 