### PR TITLE
HOTFIX: fixed instantiation of framework pointers to prevent SEGFAULT

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -76,12 +76,12 @@ int main(int argc, char* argv[]) {
       }
       case 2: {
         bart::framework::builder::FrameworkBuilder<2> builder(reporter_ptr);
-        auto framework_ptr = builder.BuildFramework("main", prm);
+        framework_ptr = builder.BuildFramework("main", prm);
         break;
       }
       case 3: {
         bart::framework::builder::FrameworkBuilder<3> builder(reporter_ptr);
-        auto framework_ptr = builder.BuildFramework("main", prm);
+        framework_ptr = builder.BuildFramework("main", prm);
         break;
       }
     }


### PR DESCRIPTION
Corrects a SEGMENTATION FAULT during instantiation of non-1D frameworks in main.cc