### PR TITLE
Square mesh reflection mapping

### DIFF
--- a/src/iteration/group/group_solve_iteration.cc
+++ b/src/iteration/group/group_solve_iteration.cc
@@ -56,6 +56,7 @@ void GroupSolveIteration<dim>::Iterate(system::System &system) {
 
   if (reporter_ptr_ != nullptr)
     reporter_ptr_->Report("..Inner group iteration\n");
+  moment_map_convergence_checker_ptr_->Reset();
   convergence::Status all_group_convergence_status;
   all_group_convergence_status.is_complete = true;
   do {

--- a/src/iteration/group/tests/group_source_iteration_test.cc
+++ b/src/iteration/group/tests/group_source_iteration_test.cc
@@ -396,6 +396,8 @@ TYPED_TEST(IterationGroupSourceSystemSolvingTest, Iterate) {
   EXPECT_CALL(*this->moment_map_convergence_checker_obs_ptr_,
               CheckFinalConvergence(Ref(current_moments), _))
               .WillOnce(Return(moment_map_status));
+  EXPECT_CALL(*this->moment_map_convergence_checker_obs_ptr_, Reset())
+      .Times(AtLeast(1));
 
   EXPECT_CALL(*mock_group_solution_ptr, GetSolution(_))
       .Times(this->total_groups * this->total_angles)

--- a/src/quadrature/quadrature_set.cc
+++ b/src/quadrature/quadrature_set.cc
@@ -41,6 +41,7 @@ std::shared_ptr<QuadraturePointI<dim>> QuadratureSet<dim>::GetBoundaryReflection
     case Boundary::kXMin: boundary = Boundary::kXMax; break;
     case Boundary::kYMin: boundary = Boundary::kYMax; break;
     case Boundary::kZMin: boundary = Boundary::kZMax; break;
+    default: break;
   }
 
   std::shared_ptr<QuadraturePointI<dim>> return_ptr = nullptr;

--- a/src/quadrature/quadrature_set.cc
+++ b/src/quadrature/quadrature_set.cc
@@ -37,6 +37,12 @@ std::shared_ptr<QuadraturePointI<dim>> QuadratureSet<dim>::GetBoundaryReflection
     problem::Boundary boundary) const {
   using Boundary = problem::Boundary;
 
+  switch (boundary) {
+    case Boundary::kXMin: boundary = Boundary::kXMax; break;
+    case Boundary::kYMin: boundary = Boundary::kYMax; break;
+    case Boundary::kZMin: boundary = Boundary::kZMax; break;
+  }
+
   std::shared_ptr<QuadraturePointI<dim>> return_ptr = nullptr;
 
   if (auto boundary_mapping = boundary_reflections_.find(boundary);

--- a/src/quadrature/quadrature_set.cc
+++ b/src/quadrature/quadrature_set.cc
@@ -32,6 +32,42 @@ bool QuadratureSet<dim>::AddPoint(
 }
 
 template<int dim>
+std::shared_ptr<QuadraturePointI<dim>> QuadratureSet<dim>::GetBoundaryReflection(
+    const std::shared_ptr<QuadraturePointI<dim>> &quadrature_point_to_reflect,
+    problem::Boundary boundary) const {
+  using Boundary = problem::Boundary;
+  auto position = quadrature_point_to_reflect->cartesian_position();
+
+  switch (boundary) {
+    case Boundary::kXMax: case Boundary::kXMin: {
+      position.at(0) *= -1;
+      break;
+    }
+    case Boundary::kYMin: case Boundary::kYMax: {
+      position.at(1) *= -1;
+      break;
+    }
+    case Boundary::kZMin: case Boundary::kZMax: {
+      position.at(2) *= -1;
+      break;
+    }
+  }
+
+  std::shared_ptr<QuadraturePointI<dim>> return_ptr = nullptr;
+  for (const auto& quadrature_point : this->quadrature_point_ptrs_) {
+    if (quadrature_point->cartesian_position() == position) {
+      return_ptr = quadrature_point;
+      break;
+    }
+  }
+
+  AssertThrow(return_ptr != nullptr,
+      dealii::ExcMessage("GetBoundaryReflection returned null reflection"))
+
+  return return_ptr;
+}
+
+template<int dim>
 void QuadratureSet<dim>::SetReflection(
     std::shared_ptr<QuadraturePointI<dim>> first_point,
     std::shared_ptr<QuadraturePointI<dim>> second_point) {
@@ -97,6 +133,7 @@ int QuadratureSet<dim>::GetQuadraturePointIndex(
     std::shared_ptr<QuadraturePointI<dim>> quadrature_point) const {
   return quadrature_point_to_index_map_.at(quadrature_point);
 }
+
 
 template class QuadratureSet<1>;
 template class QuadratureSet<2>;

--- a/src/quadrature/quadrature_set.h
+++ b/src/quadrature/quadrature_set.h
@@ -19,6 +19,9 @@ class QuadratureSet : public QuadratureSetI<dim> {
   bool AddPoint(std::shared_ptr<QuadraturePointI<dim>>);
   void SetReflection(std::shared_ptr<QuadraturePointI<dim>>,
                      std::shared_ptr<QuadraturePointI<dim>>);
+  std::shared_ptr<QuadraturePointI<dim>> GetBoundaryReflection(
+      const std::shared_ptr<QuadraturePointI<dim>>& quadrature_point_to_reflect,
+      problem::Boundary boundary) const override;
   std::shared_ptr<QuadraturePointI<dim>> GetReflection(
       std::shared_ptr<QuadraturePointI<dim>>) const override;
   std::optional<int> GetReflectionIndex(

--- a/src/quadrature/quadrature_set.h
+++ b/src/quadrature/quadrature_set.h
@@ -57,6 +57,10 @@ class QuadratureSet : public QuadratureSetI<dim> {
   //! Mapping of indices to quadrature point
   std::map<std::shared_ptr<QuadraturePointI<dim>>, int>
       quadrature_point_to_index_map_ = {};
+  //! Internal mapping of boundary reflections
+  mutable std::map<problem::Boundary, std::map<std::shared_ptr<QuadraturePointI<dim>>,
+                                               std::shared_ptr<QuadraturePointI<dim>>>>
+           boundary_reflections_;
 };
 
 } // namespace quadrature

--- a/src/quadrature/quadrature_set_i.h
+++ b/src/quadrature/quadrature_set_i.h
@@ -3,6 +3,7 @@
 
 #include "quadrature/quadrature_point_i.h"
 #include "quadrature/quadrature_types.h"
+#include "problem/parameter_types.h"
 
 #include <memory>
 #include <optional>
@@ -32,6 +33,11 @@ class QuadratureSetI {
       * @return bool indicating if an insertion was made.
    */
   virtual bool AddPoint(std::shared_ptr<QuadraturePointI<dim>>) = 0;
+
+  /// \brief Returns the quadrature point from a reflection against a boundary
+  virtual std::shared_ptr<QuadraturePointI<dim>> GetBoundaryReflection(
+      const std::shared_ptr<QuadraturePointI<dim>>&,
+      const problem::Boundary) const = 0;
 
   /// \brief Sets two points as reflections of each other.
   virtual void SetReflection(std::shared_ptr<QuadraturePointI<dim>>,

--- a/src/quadrature/quadrature_set_i.h
+++ b/src/quadrature/quadrature_set_i.h
@@ -34,7 +34,9 @@ class QuadratureSetI {
    */
   virtual bool AddPoint(std::shared_ptr<QuadraturePointI<dim>>) = 0;
 
-  /// \brief Returns the quadrature point from a reflection against a boundary
+  /*! \brief Returns the quadrature point from a reflection against a boundary
+   * This only supports square meshes.
+   */
   virtual std::shared_ptr<QuadraturePointI<dim>> GetBoundaryReflection(
       const std::shared_ptr<QuadraturePointI<dim>>&,
       const problem::Boundary) const = 0;

--- a/src/quadrature/tests/quadrature_set_mock.h
+++ b/src/quadrature/tests/quadrature_set_mock.h
@@ -18,6 +18,9 @@ class QuadratureSetMock : public QuadratureSetI<dim> {
   MOCK_METHOD(bool, AddPoint, (std::shared_ptr<QuadraturePointI<dim>>), (override));
   MOCK_METHOD(void, SetReflection, (std::shared_ptr<QuadraturePointI<dim>>,
       std::shared_ptr<QuadraturePointI<dim>>), (override));
+  MOCK_METHOD(std::shared_ptr<QuadraturePointI<dim>>, GetBoundaryReflection,
+      (const std::shared_ptr<QuadraturePointI<dim>>&, const problem::Boundary),
+      (override,const));
   MOCK_METHOD(std::shared_ptr<QuadraturePointI<dim>>, GetReflection,
               (std::shared_ptr<QuadraturePointI<dim>>), (override, const));
   MOCK_METHOD(std::optional<int>, GetReflectionIndex,


### PR DESCRIPTION
This update adds reflection mapping to `QuadratureSet` for square meshes. The database of reflections is created on-demand and cached for future calls. Updates the SAAFUpdater to use the new function for reflective boundary conditions. The mapping just uses the naive (but accurate) approach of swapping the coordinate of the incoming vector. For future work, non-square meshes will require more complex calculations. 

Also included is a minor bug fix that adds a call to `Reset()` for the all group moment convergence checker.

Closes #175.