### PR TITLE
Runtime helper

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -11,19 +11,16 @@
 #include "utility/runtime/runtime_helper.h"
 
 int main(int argc, char* argv[]) {
-  bart::utility::runtime::RuntimeHelper runtime_helper("0.2.2");
-  std::cout << runtime_helper.ProgramHeader() << std::endl;
-
   try {
+    dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+    bart::utility::runtime::RuntimeHelper runtime_helper("0.2.2");
+    std::cout << runtime_helper.ProgramHeader() << std::endl;
     runtime_helper.ParseArguments(argc, argv);
-  } catch (std::runtime_error& exc) {
-    std::cerr << "Error parsing arguments: " << exc.what() << std::endl;
-    return EXIT_FAILURE;
-  }
+    const std::string filename{runtime_helper.filename()};
+    const int n_processes = runtime_helper.n_mpi_processes();
+    const int process_id =  runtime_helper.this_mpi_process();
 
-  const std::string filename{runtime_helper.filename()};
-
-  try {
     bart::problem::ParametersDealiiHandler prm;
     dealii::ParameterHandler d2_prm;
 
@@ -31,12 +28,7 @@ int main(int argc, char* argv[]) {
     d2_prm.parse_input(filename, "");
     prm.Parse(d2_prm);
 
-    dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
-
     double k_eff_final;
-
-    const int n_processes = dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
-    const int process_id = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
 
     // Open file for output, if there are multiple processes they will end with
     // a number indicating the process number.

--- a/src/main.cc
+++ b/src/main.cc
@@ -14,7 +14,7 @@ int main(int argc, char* argv[]) {
   try {
     dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-    bart::utility::runtime::RuntimeHelper runtime_helper("0.2.2");
+    bart::utility::runtime::RuntimeHelper runtime_helper("0.2.0");
     std::cout << runtime_helper.ProgramHeader() << std::endl;
     runtime_helper.ParseArguments(argc, argv);
     const std::string filename{runtime_helper.filename()};

--- a/src/main.cc
+++ b/src/main.cc
@@ -12,14 +12,23 @@
 
 int main(int argc, char* argv[]) {
   try {
-    dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
-
     bart::utility::runtime::RuntimeHelper runtime_helper("0.2.0");
-    std::cout << runtime_helper.ProgramHeader() << std::endl;
     runtime_helper.ParseArguments(argc, argv);
+
+    if (runtime_helper.show_help()) {
+      std::cout << runtime_helper.HelpMessage() << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    std::cout << runtime_helper.ProgramHeader() << std::endl;
+    std::cout << "\nInitializing MPI\n";
+    dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+    std::cout << "\nMPI Initialized\n";
+
+    namespace MPI = dealii::Utilities::MPI;
     const std::string filename{runtime_helper.filename()};
-    const int n_processes = runtime_helper.n_mpi_processes();
-    const int process_id =  runtime_helper.this_mpi_process();
+    const int n_processes = MPI::n_mpi_processes(MPI_COMM_WORLD);
+    const int process_id =  MPI::this_mpi_process(MPI_COMM_WORLD);
 
     bart::problem::ParametersDealiiHandler prm;
     dealii::ParameterHandler d2_prm;

--- a/src/main.cc
+++ b/src/main.cc
@@ -8,6 +8,7 @@
 
 #include "framework/builder/framework_builder.h"
 #include "problem/parameters_dealii_handler.h"
+#include "utility/runtime/runtime_helper.h"
 
 int main(int argc, char* argv[]) {
   try {
@@ -18,9 +19,9 @@ int main(int argc, char* argv[]) {
       return 1;
     }
 
-    std::cout << "BAY AREA RADIATION TRANSPORT\n"
-              << "Developed at the University of California, Berkeley"
-              << std::endl;
+    const std::string version{"0.2.1"};
+    bart::utility::runtime::RuntimeHelper runtime_helper(version);
+    std::cout << runtime_helper.ProgramHeader() << std::endl;
 
     bart::problem::ParametersDealiiHandler prm;
     dealii::ParameterHandler d2_prm;

--- a/src/utility/runtime/runtime_helper.cc
+++ b/src/utility/runtime/runtime_helper.cc
@@ -1,15 +1,20 @@
 #include "utility/runtime/runtime_helper.h"
 
 #include <getopt.h>
-#include <stdlib.h>
 #include <unistd.h>
 #include <iostream>
+
+#include <deal.II/base/mpi.h>
 
 namespace bart {
 
 namespace utility {
 
 namespace runtime {
+
+RuntimeHelper::RuntimeHelper(std::string version)
+    : n_mpi_processes_(dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD)),
+      version_(version) {}
 
 void RuntimeHelper::ParseArguments(int argc, char **argv) {
   //int option_index = 0, c = 0;

--- a/src/utility/runtime/runtime_helper.cc
+++ b/src/utility/runtime/runtime_helper.cc
@@ -1,0 +1,24 @@
+#include "utility/runtime/runtime_helper.h"
+
+namespace bart {
+
+namespace utility {
+
+namespace runtime {
+
+std::string RuntimeHelper::ProgramHeader() const {
+  return std::string{"    __               __ \n"
+                     "   / /_  ____ ______/ /_\n"
+                     "  / __ \\/ __ `/ ___/ __/\n"
+                     " / /_/ / /_/ / /  / /_  \n"
+                     "/_.___/\\__,_/_/   \\__/  \n"
+                     "BAY AREA RADIATION TRANSPORT\n"
+                     "Developed at the University of California, Berkeley\n"
+                     "version: " + version_ + "\n"};
+}
+
+} // namespace runtime
+
+} // namespace utility
+
+} // namespace bart

--- a/src/utility/runtime/runtime_helper.cc
+++ b/src/utility/runtime/runtime_helper.cc
@@ -30,6 +30,12 @@ void RuntimeHelper::ParseArguments(int argc, char **argv) {
         break;
     }
   }
+
+  if (optind >= argc) {
+    throw(std::runtime_error("No filename provided."));
+  } else {
+    filename_ = argv[optind];
+  }
 }
 
 

--- a/src/utility/runtime/runtime_helper.cc
+++ b/src/utility/runtime/runtime_helper.cc
@@ -12,8 +12,13 @@ namespace utility {
 
 namespace runtime {
 
+namespace {
+namespace MPI = dealii::Utilities::MPI;
+}
+
 RuntimeHelper::RuntimeHelper(std::string version)
-    : n_mpi_processes_(dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD)),
+    : n_mpi_processes_(MPI::n_mpi_processes(MPI_COMM_WORLD)),
+      this_mpi_process_(MPI::this_mpi_process(MPI_COMM_WORLD)),
       version_(version) {}
 
 void RuntimeHelper::ParseArguments(int argc, char **argv) {

--- a/src/utility/runtime/runtime_helper.cc
+++ b/src/utility/runtime/runtime_helper.cc
@@ -1,10 +1,37 @@
 #include "utility/runtime/runtime_helper.h"
 
+#include <getopt.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <iostream>
+
 namespace bart {
 
 namespace utility {
 
 namespace runtime {
+
+void RuntimeHelper::ParseArguments(int argc, char **argv) {
+  //int option_index = 0, c = 0;
+  int c = 0;
+  optind = 0;
+  const struct option longopts[] = {
+      {"pause",     no_argument,       NULL, 'p'},
+      {NULL,        0,                 NULL,   0}
+  };
+
+  while ((c = getopt_long(argc, argv, "p", longopts, NULL)) != -1) {
+    switch(c) {
+      case 'p': {
+        do_pause_ = true;
+        break;
+      }
+    default:
+        break;
+    }
+  }
+}
+
 
 std::string RuntimeHelper::ProgramHeader() const {
   return std::string{"    __               __ \n"

--- a/src/utility/runtime/runtime_helper.cc
+++ b/src/utility/runtime/runtime_helper.cc
@@ -41,7 +41,7 @@ void RuntimeHelper::ParseArguments(int argc, char **argv) {
 
 std::string RuntimeHelper::ProgramHeader() const {
   return std::string{"    __               __ \n"
-                     "   / /_  ____ ______/ /_\n"
+                     "   / /_  ____  _____/ /_\n"
                      "  / __ \\/ __ `/ ___/ __/\n"
                      " / /_/ / /_/ / /  / /_  \n"
                      "/_.___/\\__,_/_/   \\__/  \n"

--- a/src/utility/runtime/runtime_helper.h
+++ b/src/utility/runtime/runtime_helper.h
@@ -1,0 +1,32 @@
+#ifndef BART_SRC_UTILITY_RUNTIME_RUNTIME_HELPER_H_
+#define BART_SRC_UTILITY_RUNTIME_RUNTIME_HELPER_H_
+
+#include <string>
+
+namespace bart {
+
+namespace utility {
+
+namespace runtime {
+
+class RuntimeHelper {
+ public:
+  RuntimeHelper(std::string version)
+      : version_(version) {};
+
+  /// \brief Returns the header for the BART program including version number
+  std::string ProgramHeader() const;
+
+  /// \brief Returns a string containing the version number
+  std::string version() const { return version_; }
+ private:
+  const std::string version_;
+};
+
+} // namespace runtime
+
+} // namespace utility
+
+} // namespace bart
+
+#endif //BART_SRC_UTILITY_RUNTIME_RUNTIME_HELPER_H_

--- a/src/utility/runtime/runtime_helper.h
+++ b/src/utility/runtime/runtime_helper.h
@@ -14,12 +14,19 @@ class RuntimeHelper {
   RuntimeHelper(std::string version)
       : version_(version) {};
 
+  /// \brief Parses program arguments
+  void ParseArguments(int argc, char** argv);
+
   /// \brief Returns the header for the BART program including version number
   std::string ProgramHeader() const;
 
   /// \brief Returns a string containing the version number
   std::string version() const { return version_; }
+
+  /// \brief Returns bool indicating if a pause is required before running
+  bool do_pause() const {return do_pause_; };
  private:
+  bool do_pause_ = false;
   const std::string version_;
 };
 

--- a/src/utility/runtime/runtime_helper.h
+++ b/src/utility/runtime/runtime_helper.h
@@ -25,8 +25,12 @@ class RuntimeHelper {
 
   /// \brief Returns bool indicating if a pause is required before running
   bool do_pause() const {return do_pause_; };
+
+  /// \brief Returns a string containing the filename passed to bart
+  std::string filename() const { return filename_; };
  private:
-  bool do_pause_ = false;
+  bool do_pause_{false};
+  std::string filename_{};
   const std::string version_;
 };
 

--- a/src/utility/runtime/runtime_helper.h
+++ b/src/utility/runtime/runtime_helper.h
@@ -17,11 +17,17 @@ class RuntimeHelper {
   /// \brief Parses program arguments
   void ParseArguments(int argc, char** argv);
 
+  /// \brief Returns the help message for the BART program
+  std::string HelpMessage() const;
+
   /// \brief Returns the header for the BART program including version number
   std::string ProgramHeader() const;
 
   /// \brief Returns a string containing the version number
   std::string version() const { return version_; }
+
+  /// \brief Returns bool indicating if the program should immediately terminate
+  bool show_help() const { return show_help_; }
 
   /// \brief Returns bool indicating if a pause is required before running
   bool do_pause() const {return do_pause_; };
@@ -29,16 +35,10 @@ class RuntimeHelper {
   /// \brief Returns a string containing the filename passed to bart
   std::string filename() const { return filename_; };
 
-  /// \brief Returns number of MPI processes
-  int n_mpi_processes() const { return n_mpi_processes_; }
-
-  /// \brief Returns current MPI process
-  int this_mpi_process() const { return this_mpi_process_; }
  private:
+  bool show_help_{false};
   bool do_pause_{false};
   std::string filename_{};
-  const int n_mpi_processes_;
-  const int this_mpi_process_;
   const std::string version_;
 };
 

--- a/src/utility/runtime/runtime_helper.h
+++ b/src/utility/runtime/runtime_helper.h
@@ -3,6 +3,7 @@
 
 #include <string>
 
+
 namespace bart {
 
 namespace utility {
@@ -11,8 +12,7 @@ namespace runtime {
 
 class RuntimeHelper {
  public:
-  RuntimeHelper(std::string version)
-      : version_(version) {};
+  RuntimeHelper(std::string version);
 
   /// \brief Parses program arguments
   void ParseArguments(int argc, char** argv);
@@ -28,9 +28,13 @@ class RuntimeHelper {
 
   /// \brief Returns a string containing the filename passed to bart
   std::string filename() const { return filename_; };
+
+  /// \brief Returns number of MPI processes
+  int n_mpi_processes() const { return n_mpi_processes_; }
  private:
   bool do_pause_{false};
   std::string filename_{};
+  const int n_mpi_processes_;
   const std::string version_;
 };
 

--- a/src/utility/runtime/runtime_helper.h
+++ b/src/utility/runtime/runtime_helper.h
@@ -31,10 +31,14 @@ class RuntimeHelper {
 
   /// \brief Returns number of MPI processes
   int n_mpi_processes() const { return n_mpi_processes_; }
+
+  /// \brief Returns current MPI process
+  int this_mpi_process() const { return this_mpi_process_; }
  private:
   bool do_pause_{false};
   std::string filename_{};
   const int n_mpi_processes_;
+  const int this_mpi_process_;
   const std::string version_;
 };
 

--- a/src/utility/runtime/tests/runtime_helper_test.cc
+++ b/src/utility/runtime/tests/runtime_helper_test.cc
@@ -48,37 +48,67 @@ TEST_F(UtilityRuntimeHelperTest, ProgramHeader) {
   EXPECT_THAT(header, HasSubstr(version_));
 }
 
+TEST_F(UtilityRuntimeHelperTest, HelpMessage) {
+  auto help_message = test_helper.HelpMessage();
+  EXPECT_NE(help_message, "");
+}
+
 TEST_F(UtilityRuntimeHelperTest, PauseProgram) {
   MakeArgv("bart -p " + filename);
   EXPECT_FALSE(test_helper.do_pause());
+  EXPECT_FALSE(test_helper.show_help());
   test_helper.ParseArguments(argc_, argv_);
   EXPECT_TRUE(test_helper.do_pause());
+  EXPECT_FALSE(test_helper.show_help());
   EXPECT_EQ(test_helper.filename(), filename);
 }
 
 TEST_F(UtilityRuntimeHelperTest, PauseProgramLong) {
   MakeArgv("bart --pause " + filename);
   EXPECT_FALSE(test_helper.do_pause());
+  EXPECT_FALSE(test_helper.show_help());
   test_helper.ParseArguments(argc_, argv_);
   EXPECT_TRUE(test_helper.do_pause());
+  EXPECT_FALSE(test_helper.show_help());
   EXPECT_EQ(test_helper.filename(), filename);
 }
 
 TEST_F(UtilityRuntimeHelperTest, NoFileName) {
   MakeArgv("bart --pause");
   EXPECT_FALSE(test_helper.do_pause());
+  EXPECT_FALSE(test_helper.show_help());
   EXPECT_ANY_THROW({
                      test_helper.ParseArguments(argc_, argv_);
                    });
 }
 
-TEST_F(UtilityRuntimeHelperTest, MPIProcesses) {
-  EXPECT_EQ(test_helper.n_mpi_processes(),
-            dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD));
-  EXPECT_EQ(test_helper.this_mpi_process(),
-            dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD));
+TEST_F(UtilityRuntimeHelperTest, HelpLong) {
+  MakeArgv("bart --help");
+  EXPECT_FALSE(test_helper.show_help());
+  test_helper.ParseArguments(argc_, argv_);
+  EXPECT_TRUE(test_helper.show_help());
 }
 
+TEST_F(UtilityRuntimeHelperTest, Help) {
+  MakeArgv("bart -h");
+  EXPECT_FALSE(test_helper.show_help());
+  test_helper.ParseArguments(argc_, argv_);
+  EXPECT_TRUE(test_helper.show_help());
+}
+
+TEST_F(UtilityRuntimeHelperTest, UnknownOption) {
+  MakeArgv("bart -k " + filename);
+  EXPECT_FALSE(test_helper.show_help());
+  test_helper.ParseArguments(argc_, argv_);
+  EXPECT_TRUE(test_helper.show_help());
+}
+
+TEST_F(UtilityRuntimeHelperTest, UnknownLongOption) {
+  MakeArgv("bart --kill " + filename);
+  EXPECT_FALSE(test_helper.show_help());
+  test_helper.ParseArguments(argc_, argv_);
+  EXPECT_TRUE(test_helper.show_help());
+}
 
 
 

--- a/src/utility/runtime/tests/runtime_helper_test.cc
+++ b/src/utility/runtime/tests/runtime_helper_test.cc
@@ -3,6 +3,8 @@
 #include <sstream>
 #include <vector>
 
+#include <deal.II/base/mpi.h>
+
 #include "test_helpers/gmock_wrapper.h"
 
 namespace  {
@@ -68,6 +70,11 @@ TEST_F(UtilityRuntimeHelperTest, NoFileName) {
   EXPECT_ANY_THROW({
                      test_helper.ParseArguments(argc_, argv_);
                    });
+}
+
+TEST_F(UtilityRuntimeHelperTest, MPIProcesses) {
+  EXPECT_EQ(test_helper.n_mpi_processes(),
+            dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD));
 }
 
 

--- a/src/utility/runtime/tests/runtime_helper_test.cc
+++ b/src/utility/runtime/tests/runtime_helper_test.cc
@@ -12,7 +12,7 @@ using ::testing::HasSubstr;
 
 class UtilityRuntimeHelperTest : public ::testing::Test {
  public:
-  const std::string version_{"7.6.9"};
+  const std::string version_{"7.6.9"}, filename{"testfile.input"};
   utility::runtime::RuntimeHelper test_helper{version_};
 
   void MakeArgv(std::string to_convert);
@@ -47,18 +47,30 @@ TEST_F(UtilityRuntimeHelperTest, ProgramHeader) {
 }
 
 TEST_F(UtilityRuntimeHelperTest, PauseProgram) {
-  MakeArgv("bart -p");
+  MakeArgv("bart -p " + filename);
   EXPECT_FALSE(test_helper.do_pause());
   test_helper.ParseArguments(argc_, argv_);
   EXPECT_TRUE(test_helper.do_pause());
+  EXPECT_EQ(test_helper.filename(), filename);
 }
 
 TEST_F(UtilityRuntimeHelperTest, PauseProgramLong) {
-  MakeArgv("bart --pause");
+  MakeArgv("bart --pause " + filename);
   EXPECT_FALSE(test_helper.do_pause());
   test_helper.ParseArguments(argc_, argv_);
   EXPECT_TRUE(test_helper.do_pause());
+  EXPECT_EQ(test_helper.filename(), filename);
 }
+
+TEST_F(UtilityRuntimeHelperTest, NoFileName) {
+  MakeArgv("bart --pause");
+  EXPECT_FALSE(test_helper.do_pause());
+  EXPECT_ANY_THROW({
+                     test_helper.ParseArguments(argc_, argv_);
+                   });
+}
+
+
 
 
 

--- a/src/utility/runtime/tests/runtime_helper_test.cc
+++ b/src/utility/runtime/tests/runtime_helper_test.cc
@@ -1,5 +1,8 @@
 #include "utility/runtime/runtime_helper.h"
 
+#include <sstream>
+#include <vector>
+
 #include "test_helpers/gmock_wrapper.h"
 
 namespace  {
@@ -11,7 +14,28 @@ class UtilityRuntimeHelperTest : public ::testing::Test {
  public:
   const std::string version_{"7.6.9"};
   utility::runtime::RuntimeHelper test_helper{version_};
+
+  void MakeArgv(std::string to_convert);
+
+  std::vector<std::string> arguments_;
+  std::vector<char*> argv_vector_;
+  char** argv_;
+  int argc_;
 };
+
+void UtilityRuntimeHelperTest::MakeArgv(std::string to_convert) {
+  std::istringstream iss(to_convert);
+  std::vector<std::string> arguments(std::istream_iterator<std::string>{iss},
+                                     std::istream_iterator<std::string>());
+  arguments_ = arguments;
+  for (auto& arg : arguments_) {
+    argv_vector_.push_back(const_cast<char*>(arg.data()));
+  }
+  argv_vector_.push_back(nullptr);
+
+  argv_ = const_cast<char**>(argv_vector_.data());
+  argc_ = argv_vector_.size() - 1;
+}
 
 TEST_F(UtilityRuntimeHelperTest, Version) {
   EXPECT_EQ(test_helper.version(), version_);
@@ -20,6 +44,20 @@ TEST_F(UtilityRuntimeHelperTest, Version) {
 TEST_F(UtilityRuntimeHelperTest, ProgramHeader) {
   auto header = test_helper.ProgramHeader();
   EXPECT_THAT(header, HasSubstr(version_));
+}
+
+TEST_F(UtilityRuntimeHelperTest, PauseProgram) {
+  MakeArgv("bart -p");
+  EXPECT_FALSE(test_helper.do_pause());
+  test_helper.ParseArguments(argc_, argv_);
+  EXPECT_TRUE(test_helper.do_pause());
+}
+
+TEST_F(UtilityRuntimeHelperTest, PauseProgramLong) {
+  MakeArgv("bart --pause");
+  EXPECT_FALSE(test_helper.do_pause());
+  test_helper.ParseArguments(argc_, argv_);
+  EXPECT_TRUE(test_helper.do_pause());
 }
 
 

--- a/src/utility/runtime/tests/runtime_helper_test.cc
+++ b/src/utility/runtime/tests/runtime_helper_test.cc
@@ -75,6 +75,8 @@ TEST_F(UtilityRuntimeHelperTest, NoFileName) {
 TEST_F(UtilityRuntimeHelperTest, MPIProcesses) {
   EXPECT_EQ(test_helper.n_mpi_processes(),
             dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD));
+  EXPECT_EQ(test_helper.this_mpi_process(),
+            dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD));
 }
 
 

--- a/src/utility/runtime/tests/runtime_helper_test.cc
+++ b/src/utility/runtime/tests/runtime_helper_test.cc
@@ -1,0 +1,27 @@
+#include "utility/runtime/runtime_helper.h"
+
+#include "test_helpers/gmock_wrapper.h"
+
+namespace  {
+
+using namespace bart;
+using ::testing::HasSubstr;
+
+class UtilityRuntimeHelperTest : public ::testing::Test {
+ public:
+  const std::string version_{"7.6.9"};
+  utility::runtime::RuntimeHelper test_helper{version_};
+};
+
+TEST_F(UtilityRuntimeHelperTest, Version) {
+  EXPECT_EQ(test_helper.version(), version_);
+}
+
+TEST_F(UtilityRuntimeHelperTest, ProgramHeader) {
+  auto header = test_helper.ProgramHeader();
+  EXPECT_THAT(header, HasSubstr(version_));
+}
+
+
+
+} // namespace


### PR DESCRIPTION
Adds `utility::runtime::RuntimeHelper` to provide useful and tested functions to main including:
- Program run header w/version number
- Various MPI values (number of processes, current process)
- Parsing of input parameters (includes `--pause` for pausing before run)
- Bool indicating if a pause is requested before running.

Closes #189 