### PR TITLE
Drift-diffusion factories

### DIFF
--- a/src/calculator/drift_diffusion/drift_diffusion_vector_calculator.cpp
+++ b/src/calculator/drift_diffusion/drift_diffusion_vector_calculator.cpp
@@ -1,6 +1,15 @@
 #include "calculator/drift_diffusion/drift_diffusion_vector_calculator.hpp"
 
+#include "calculator/drift_diffusion/factory.hpp"
+
 namespace bart::calculator::drift_diffusion {
+
+template <int dim>
+bool DriftDiffusionVectorCalculator<dim>::is_registered_ =
+    DriftDiffusionVectorCalculatorIFactory<dim>::get()
+        .RegisterConstructor(DriftDiffusionVectorCalculatorName::kDefaultImplementation,
+                             []() -> std::unique_ptr<DriftDiffusionVectorCalculatorI<dim>>
+                             { return std::make_unique<DriftDiffusionVectorCalculator<dim>>(); });
 
 template<int dim>
 auto DriftDiffusionVectorCalculator<dim>::DriftDiffusionVector(const double scalar_flux,

--- a/src/calculator/drift_diffusion/drift_diffusion_vector_calculator.hpp
+++ b/src/calculator/drift_diffusion/drift_diffusion_vector_calculator.hpp
@@ -14,6 +14,8 @@ class DriftDiffusionVectorCalculator : public DriftDiffusionVectorCalculatorI<di
                                           const Tensor& current,
                                           const Tensor& shape_gradient,
                                           const double diffusion_coefficient) const -> Tensor override;
+ private:
+  static bool is_registered_;
 };
 
 } // namespace bart::calculator::drift_diffusion

--- a/src/calculator/drift_diffusion/factory.hpp
+++ b/src/calculator/drift_diffusion/factory.hpp
@@ -1,0 +1,21 @@
+#ifndef BART_SRC_CALCULATOR_DRIFT_DIFFUSION_FACTORY_HPP_
+#define BART_SRC_CALCULATOR_DRIFT_DIFFUSION_FACTORY_HPP_
+
+#include "utility/factory/auto_registering_factory.hpp"
+
+namespace bart::calculator::drift_diffusion {
+
+template <int dim> class DriftDiffusionVectorCalculatorI;
+
+enum class DriftDiffusionVectorCalculatorName {
+  kDefaultImplementation = 0,
+};
+
+template <int dim, typename ...T>
+class DriftDiffusionVectorCalculatorIFactory : public utility::factory::AutoRegisteringFactory<
+    DriftDiffusionVectorCalculatorName,
+    std::unique_ptr<DriftDiffusionVectorCalculatorI<dim>>(*)(T...)> {};
+
+} // namespace bart::calculator::drift_diffusion
+
+#endif //BART_SRC_CALCULATOR_DRIFT_DIFFUSION_FACTORY_HPP_

--- a/src/formulation/scalar/drift_diffusion.cpp
+++ b/src/formulation/scalar/drift_diffusion.cpp
@@ -1,4 +1,5 @@
 #include "formulation/scalar/drift_diffusion.hpp"
+#include "formulation/scalar/scalar_formulation_factory.hpp"
 
 namespace bart::formulation::scalar {
 
@@ -20,6 +21,23 @@ DriftDiffusion<dim>::DriftDiffusion(std::shared_ptr<FiniteElement> finite_elemen
   cell_degrees_of_freedom_ = finite_element_ptr->dofs_per_cell();
   face_quadrature_points_ = finite_element_ptr->n_face_quad_pts();
 }
+
+template <int dim>
+bool DriftDiffusion<dim>::is_registered_ =
+    DriftDiffusionIFactory<dim, std::shared_ptr<FiniteElement>, std::shared_ptr<CrossSections>,
+                           std::shared_ptr<DriftDiffusionCalculator>, std::shared_ptr<AngularFluxIntegrator>>::get()
+        .RegisterConstructor(DriftDiffusionFormulationName::kDefaultImplementation,
+                             [](std::shared_ptr<FiniteElement> finite_element_ptr,
+                                std::shared_ptr<CrossSections> cross_sections_ptr,
+                                std::shared_ptr<DriftDiffusionCalculator> drift_diffusion_calculator_ptr,
+                                std::shared_ptr<AngularFluxIntegrator> angular_flux_integrator_ptr)
+                                -> std::unique_ptr<DriftDiffusionI<dim>> {
+                               return std::make_unique<DriftDiffusion<dim>>(finite_element_ptr,
+                                                                            cross_sections_ptr,
+                                                                            drift_diffusion_calculator_ptr,
+                                                                            angular_flux_integrator_ptr);
+                             }
+        );
 
 template<int dim>
 void DriftDiffusion<dim>::FillCellBoundaryTerm(Matrix& to_fill,

--- a/src/formulation/scalar/drift_diffusion.hpp
+++ b/src/formulation/scalar/drift_diffusion.hpp
@@ -13,6 +13,8 @@
 
 namespace bart::formulation::scalar {
 
+template <int, typename ...> class DriftDiffusionIFactory;
+
 template <int dim>
 class DriftDiffusion : public DriftDiffusionI<dim>, public utility::HasDependencies {
  public:
@@ -24,6 +26,8 @@ class DriftDiffusion : public DriftDiffusionI<dim>, public utility::HasDependenc
   using typename DriftDiffusionI<dim>::CellPtr;
   using typename DriftDiffusionI<dim>::Vector;
   using typename DriftDiffusionI<dim>::VectorMap;
+
+  using Factory = DriftDiffusionIFactory<dim, std::shared_ptr<FiniteElement>, std::shared_ptr<CrossSections>, std::shared_ptr<DriftDiffusionCalculator>, std::shared_ptr<AngularFluxIntegrator>>;
 
   DriftDiffusion(std::shared_ptr<FiniteElement>,
                  std::shared_ptr<CrossSections>,

--- a/src/formulation/scalar/drift_diffusion.hpp
+++ b/src/formulation/scalar/drift_diffusion.hpp
@@ -47,7 +47,7 @@ class DriftDiffusion : public DriftDiffusionI<dim>, public utility::HasDependenc
   auto cross_sections_ptr() const -> CrossSections* { return cross_sections_ptr_.get(); }
   auto drift_diffusion_calculator_ptr() const -> DriftDiffusionCalculator* {
     return drift_diffusion_calculator_ptr_.get(); }
- private:
+ protected:
   std::shared_ptr<FiniteElement> finite_element_ptr_{ nullptr };
   std::shared_ptr<CrossSections> cross_sections_ptr_{ nullptr };
   std::shared_ptr<DriftDiffusionCalculator> drift_diffusion_calculator_ptr_{ nullptr };
@@ -55,6 +55,8 @@ class DriftDiffusion : public DriftDiffusionI<dim>, public utility::HasDependenc
   int cell_quadrature_points_{ 0 };
   int cell_degrees_of_freedom_{ 0 };
   int face_quadrature_points_{ 0 };
+ private:
+  static bool is_registered_;
 };
 
 } // namespace bart::formulation::scalar

--- a/src/formulation/scalar/scalar_formulation_factory.hpp
+++ b/src/formulation/scalar/scalar_formulation_factory.hpp
@@ -1,0 +1,21 @@
+#ifndef BART_SRC_FORMULATION_SCALAR_SCALAR_FORMULATION_FACTORY_HPP_
+#define BART_SRC_FORMULATION_SCALAR_SCALAR_FORMULATION_FACTORY_HPP_
+
+#include "utility/factory/auto_registering_factory.hpp"
+
+namespace bart::formulation::scalar {
+
+template <int dim> class DriftDiffusionI;
+
+enum class DriftDiffusionFormulationName {
+  kDefaultImplementation = 0,
+};
+
+template <int dim, typename ...T>
+class DriftDiffusionIFactory : public utility::factory::AutoRegisteringFactory<
+    DriftDiffusionFormulationName,
+    std::unique_ptr<DriftDiffusionI<dim>>(*)(T...)> {};
+
+} // namespace bart::formulation::scalar
+
+#endif //BART_SRC_FORMULATION_SCALAR_SCALAR_FORMULATION_FACTORY_HPP_

--- a/src/formulation/updater/drift_diffusion_updater.hpp
+++ b/src/formulation/updater/drift_diffusion_updater.hpp
@@ -11,6 +11,8 @@
 
 namespace bart::formulation::updater {
 
+template <int, typename ...T> class DriftDiffusionUpdaterFactory;
+
 template <int dim>
 class DriftDiffusionUpdater : public DiffusionUpdater<dim>, public utility::HasDependencies {
  public:
@@ -20,6 +22,8 @@ class DriftDiffusionUpdater : public DiffusionUpdater<dim>, public utility::HasD
   using IntegratedFluxCalculator = quadrature::calculators::AngularFluxIntegratorI;
   using HighOrderMoments = system::moments::SphericalHarmonicI;
   using Stamper = typename DiffusionUpdater<dim>::StamperType;
+
+  using Factory = DriftDiffusionUpdaterFactory<dim, std::unique_ptr<DiffusionFormulation>, std::unique_ptr<DriftDiffusionFormulation>, std::shared_ptr<Stamper>, std::shared_ptr<IntegratedFluxCalculator>,std::shared_ptr<HighOrderMoments>, AngularFluxStorageMap&, std::unordered_set<problem::Boundary>>;
 
   DriftDiffusionUpdater(std::unique_ptr<DiffusionFormulation>,
                         std::unique_ptr<DriftDiffusionFormulation>,
@@ -45,6 +49,8 @@ class DriftDiffusionUpdater : public DiffusionUpdater<dim>, public utility::HasD
   std::shared_ptr<HighOrderMoments> high_order_moments_;
   std::unique_ptr<DriftDiffusionFormulation> drift_diffusion_formulation_ptr_{ nullptr };
   std::shared_ptr<IntegratedFluxCalculator> integrated_flux_calculator_ptr_{ nullptr };
+ private:
+  static bool is_registered_;
 };
 
 } // namespace bart::formulation::updater

--- a/src/formulation/updater/formulation_updater_factories.hpp
+++ b/src/formulation/updater/formulation_updater_factories.hpp
@@ -1,0 +1,21 @@
+#ifndef BART_SRC_FORMULATION_UPDATER_FORMULATION_UPDATER_FACTORIES_HPP_
+#define BART_SRC_FORMULATION_UPDATER_FORMULATION_UPDATER_FACTORIES_HPP_
+
+#include "utility/factory/auto_registering_factory.hpp"
+
+namespace bart::formulation::updater {
+
+template <int dim> class DriftDiffusionUpdater;
+
+enum class DriftDiffusionUpdaterName {
+  kDefaultImplementation = 0,
+};
+
+template <int dim, typename ...T>
+class DriftDiffusionUpdaterFactory : public utility::factory::AutoRegisteringFactory<
+    DriftDiffusionUpdaterName,
+    std::unique_ptr<DriftDiffusionUpdater<dim>>(*)(T...)> {};
+
+} // namespace bart::formulation::updater
+
+#endif //BART_SRC_FORMULATION_UPDATER_FORMULATION_UPDATER_FACTORIES_HPP_

--- a/src/framework/builder/framework_builder.cpp
+++ b/src/framework/builder/framework_builder.cpp
@@ -83,6 +83,13 @@ FrameworkBuilder<dim>::FrameworkBuilder(std::unique_ptr<Validator> validator_ptr
 // =============================================================================
 
 template<int dim>
+auto FrameworkBuilder<dim>::BuildAngularFluxIntegrator(const std::shared_ptr<QuadratureSet> quadrature_set_ptr)
+-> std::unique_ptr<AngularFluxIntegrator> {
+  return quadrature::calculators::AngularFluxIntegrator<dim>::Factory::get()
+      .GetConstructor(quadrature::calculators::AngularFluxIntegratorName::kDefaultImplementation)(quadrature_set_ptr);
+}
+
+template<int dim>
 auto FrameworkBuilder<dim>::BuildDiffusionFormulation(const std::shared_ptr<FiniteElement>& finite_element_ptr,
                                                       const std::shared_ptr<data::CrossSections>& cross_sections_ptr,
                                                       const DiffusionFormulationImpl implementation)

--- a/src/framework/builder/framework_builder.cpp
+++ b/src/framework/builder/framework_builder.cpp
@@ -9,6 +9,7 @@
 #include <calculator/drift_diffusion/drift_diffusion_vector_calculator.hpp>
 #include <calculator/drift_diffusion/factory.hpp>
 #include <formulation/scalar/scalar_formulation_factory.hpp>
+#include <formulation/updater/formulation_updater_factories.hpp>
 
 // Builders & factories
 #include "solver/builder/solver_builder.hpp"
@@ -185,13 +186,15 @@ auto FrameworkBuilder<dim>::BuildUpdaterPointers(
   }
 
   using ReturnType = formulation::updater::DriftDiffusionUpdater<dim>;
-  auto drift_diffusion_updater_ptr = std::make_shared<ReturnType>(std::move(diffusion_formulation_ptr),
-                                                                  std::move(drift_diffusion_formulation_ptr),
-                                                                  stamper_ptr,
-                                                                  angular_flux_integrator_ptr,
-                                                                  higher_order_moments_ptr,
-                                                                  angular_flux_storage,
-                                                                  reflective_boundary_set);
+  auto implementation_name{ formulation::updater::DriftDiffusionUpdaterName::kDefaultImplementation };
+  auto drift_diffusion_updater_ptr = Shared(ReturnType::Factory::get().GetConstructor(implementation_name)(
+      std::move(diffusion_formulation_ptr),
+      std::move(drift_diffusion_formulation_ptr),
+      stamper_ptr,
+      angular_flux_integrator_ptr,
+      higher_order_moments_ptr,
+      angular_flux_storage,
+      reflective_boundary_set));
 
   return_struct.fixed_updater_ptr = drift_diffusion_updater_ptr;
   return_struct.fission_source_updater_ptr = drift_diffusion_updater_ptr;

--- a/src/framework/builder/framework_builder.cpp
+++ b/src/framework/builder/framework_builder.cpp
@@ -108,11 +108,10 @@ auto FrameworkBuilder<dim>::BuildDiffusionFormulation(const std::shared_ptr<Fini
 
 template<int dim>
 auto FrameworkBuilder<dim>::BuildDriftDiffusionFormulation(
+    const std::shared_ptr<AngularFluxIntegrator>& angular_flux_integrator_ptr,
     const std::shared_ptr<FiniteElement>& finite_element_ptr,
     const std::shared_ptr<data::CrossSections>& cross_sections_ptr,
     const std::shared_ptr<QuadratureSet> quadrature_set_ptr) -> std::unique_ptr<DriftDiffusionFormulation> {
-  auto angular_flux_integrator_ptr = Shared(quadrature::calculators::AngularFluxIntegrator<dim>::Factory::get()
-      .GetConstructor(quadrature::calculators::AngularFluxIntegratorName::kDefaultImplementation)(quadrature_set_ptr));
   auto drift_diffusion_vector_calculator_ptr = Shared(calculator::drift_diffusion::DriftDiffusionVectorCalculatorIFactory<dim>::get()
       .GetConstructor(calculator::drift_diffusion::DriftDiffusionVectorCalculatorName::kDefaultImplementation)());
   return formulation::scalar::DriftDiffusion<dim>::Factory::get()

--- a/src/framework/builder/framework_builder.cpp
+++ b/src/framework/builder/framework_builder.cpp
@@ -111,8 +111,7 @@ template<int dim>
 auto FrameworkBuilder<dim>::BuildDriftDiffusionFormulation(
     const std::shared_ptr<AngularFluxIntegrator>& angular_flux_integrator_ptr,
     const std::shared_ptr<FiniteElement>& finite_element_ptr,
-    const std::shared_ptr<data::CrossSections>& cross_sections_ptr,
-    const std::shared_ptr<QuadratureSet> quadrature_set_ptr) -> std::unique_ptr<DriftDiffusionFormulation> {
+    const std::shared_ptr<data::CrossSections>& cross_sections_ptr) -> std::unique_ptr<DriftDiffusionFormulation> {
   auto drift_diffusion_vector_calculator_ptr = Shared(calculator::drift_diffusion::DriftDiffusionVectorCalculatorIFactory<dim>::get()
       .GetConstructor(calculator::drift_diffusion::DriftDiffusionVectorCalculatorName::kDefaultImplementation)());
   return formulation::scalar::DriftDiffusion<dim>::Factory::get()

--- a/src/framework/builder/framework_builder.hpp
+++ b/src/framework/builder/framework_builder.hpp
@@ -41,6 +41,7 @@ class FrameworkBuilder : public data_port::StatusDataPort, public FrameworkBuild
   using typename FrameworkBuilderI<dim>::QuadratureSet;
   using typename FrameworkBuilderI<dim>::Stamper;
   using typename FrameworkBuilderI<dim>::SAAFFormulation;
+  using typename FrameworkBuilderI<dim>::SphericalHarmonicMoments;
   using typename FrameworkBuilderI<dim>::SingleGroupSolver;
   using typename FrameworkBuilderI<dim>::System;
   using typename FrameworkBuilderI<dim>::Validator;
@@ -147,6 +148,14 @@ class FrameworkBuilder : public data_port::StatusDataPort, public FrameworkBuild
                                  const std::size_t solution_size,
                                  bool is_eigenvalue_problem,
                                  bool need_rhs_boundary_condition) -> std::unique_ptr<System> override;
+
+  [[nodiscard]] auto BuildUpdaterPointers(std::unique_ptr<DiffusionFormulation>,
+                                    std::unique_ptr<DriftDiffusionFormulation>,
+                                    std::shared_ptr<Stamper>,
+                                    std::shared_ptr<AngularFluxIntegrator>,
+                                    std::shared_ptr<SphericalHarmonicMoments>,
+                                    AngularFluxStorage&,
+                                    const std::map<problem::Boundary, bool>&) -> UpdaterPointers override;
   [[nodiscard]] auto BuildUpdaterPointers(
       std::unique_ptr<DiffusionFormulation>,
       std::unique_ptr<Stamper>,

--- a/src/framework/builder/framework_builder.hpp
+++ b/src/framework/builder/framework_builder.hpp
@@ -77,8 +77,7 @@ class FrameworkBuilder : public data_port::StatusDataPort, public FrameworkBuild
   [[nodiscard]] auto BuildDriftDiffusionFormulation(
       const std::shared_ptr<AngularFluxIntegrator>&,
       const std::shared_ptr<FiniteElement>&,
-      const std::shared_ptr<data::CrossSections>&,
-      const std::shared_ptr<QuadratureSet>) -> std::unique_ptr<DriftDiffusionFormulation> override;
+      const std::shared_ptr<data::CrossSections>&) -> std::unique_ptr<DriftDiffusionFormulation> override;
 
   [[nodiscard]] auto BuildDomain(const FrameworkParameters::DomainSize,
                                  const FrameworkParameters::NumberOfCells,

--- a/src/framework/builder/framework_builder.hpp
+++ b/src/framework/builder/framework_builder.hpp
@@ -22,6 +22,7 @@ template <int dim>
 class FrameworkBuilder : public data_port::StatusDataPort, public FrameworkBuilderI<dim> {
  public:
   // New using types from refactor
+  using typename FrameworkBuilderI<dim>::AngularFluxIntegrator;
   using typename FrameworkBuilderI<dim>::CrossSections;
   using typename FrameworkBuilderI<dim>::DiffusionFormulation;
   using typename FrameworkBuilderI<dim>::DriftDiffusionFormulation;
@@ -62,6 +63,9 @@ class FrameworkBuilder : public data_port::StatusDataPort, public FrameworkBuild
 
   FrameworkBuilder(std::unique_ptr<Validator> validator_ptr);
   ~FrameworkBuilder() = default;
+
+  [[nodiscard]] auto BuildAngularFluxIntegrator(
+      const std::shared_ptr<QuadratureSet>) -> std::unique_ptr<AngularFluxIntegrator> override;
 
   [[nodiscard]] auto BuildDiffusionFormulation(
       const std::shared_ptr<FiniteElement>&,

--- a/src/framework/builder/framework_builder.hpp
+++ b/src/framework/builder/framework_builder.hpp
@@ -74,6 +74,7 @@ class FrameworkBuilder : public data_port::StatusDataPort, public FrameworkBuild
   -> std::unique_ptr<DiffusionFormulation> override;
 
   [[nodiscard]] auto BuildDriftDiffusionFormulation(
+      const std::shared_ptr<AngularFluxIntegrator>&,
       const std::shared_ptr<FiniteElement>&,
       const std::shared_ptr<data::CrossSections>&,
       const std::shared_ptr<QuadratureSet>) -> std::unique_ptr<DriftDiffusionFormulation> override;

--- a/src/framework/builder/framework_builder.hpp
+++ b/src/framework/builder/framework_builder.hpp
@@ -24,6 +24,7 @@ class FrameworkBuilder : public data_port::StatusDataPort, public FrameworkBuild
   // New using types from refactor
   using typename FrameworkBuilderI<dim>::CrossSections;
   using typename FrameworkBuilderI<dim>::DiffusionFormulation;
+  using typename FrameworkBuilderI<dim>::DriftDiffusionFormulation;
   using typename FrameworkBuilderI<dim>::Domain;
   using typename FrameworkBuilderI<dim>::FiniteElement;
   using typename FrameworkBuilderI<dim>::FrameworkI;
@@ -67,6 +68,12 @@ class FrameworkBuilder : public data_port::StatusDataPort, public FrameworkBuild
       const std::shared_ptr<data::CrossSections>&,
       const DiffusionFormulationImpl implementation = DiffusionFormulationImpl::kDefault)
   -> std::unique_ptr<DiffusionFormulation> override;
+
+  [[nodiscard]] auto BuildDriftDiffusionFormulation(
+      const std::shared_ptr<FiniteElement>&,
+      const std::shared_ptr<data::CrossSections>&,
+      const std::shared_ptr<QuadratureSet>) -> std::unique_ptr<DriftDiffusionFormulation> override;
+
   [[nodiscard]] auto BuildDomain(const FrameworkParameters::DomainSize,
                                  const FrameworkParameters::NumberOfCells,
                                  const std::shared_ptr<FiniteElement>&,

--- a/src/framework/builder/framework_builder_i.hpp
+++ b/src/framework/builder/framework_builder_i.hpp
@@ -99,6 +99,7 @@ class FrameworkBuilderI {
       const std::shared_ptr<data::CrossSections>&,
       const DiffusionFormulationImpl) -> std::unique_ptr<DiffusionFormulation> = 0;
   virtual auto BuildDriftDiffusionFormulation(
+      const std::shared_ptr<AngularFluxIntegrator>&,
       const std::shared_ptr<FiniteElement>&,
       const std::shared_ptr<data::CrossSections>&,
       const std::shared_ptr<QuadratureSet>) -> std::unique_ptr<DriftDiffusionFormulation> = 0;

--- a/src/framework/builder/framework_builder_i.hpp
+++ b/src/framework/builder/framework_builder_i.hpp
@@ -14,6 +14,7 @@
 #include "framework/framework_parameters.hpp"
 #include "formulation/angular/self_adjoint_angular_flux_i.h"
 #include "formulation/scalar/diffusion_i.h"
+#include "formulation/scalar/drift_diffusion_i.hpp"
 #include "formulation/updater/boundary_conditions_updater_i.h"
 #include "formulation/updater/fission_source_updater_i.h"
 #include "formulation/updater/fixed_updater_i.h"
@@ -41,6 +42,7 @@ class FrameworkBuilderI {
   // Classes built by member functions
   using CrossSections = data::CrossSections;
   using DiffusionFormulation = typename formulation::scalar::DiffusionI<dim>;
+  using DriftDiffusionFormulation = typename formulation::scalar::DriftDiffusionI<dim>;
   using Domain = typename domain::DefinitionI<dim>;
   using FiniteElement = typename domain::finite_element::FiniteElementI<dim>;
   using FrameworkI = framework::FrameworkI;
@@ -92,6 +94,10 @@ class FrameworkBuilderI {
       const std::shared_ptr<FiniteElement>&,
       const std::shared_ptr<data::CrossSections>&,
       const DiffusionFormulationImpl) -> std::unique_ptr<DiffusionFormulation> = 0;
+  virtual auto BuildDriftDiffusionFormulation(
+      const std::shared_ptr<FiniteElement>&,
+      const std::shared_ptr<data::CrossSections>&,
+      const std::shared_ptr<QuadratureSet>) -> std::unique_ptr<DriftDiffusionFormulation> = 0;
   virtual auto BuildDomain(const FrameworkParameters::DomainSize,
                            const FrameworkParameters::NumberOfCells,
                            const std::shared_ptr<FiniteElement>&,

--- a/src/framework/builder/framework_builder_i.hpp
+++ b/src/framework/builder/framework_builder_i.hpp
@@ -103,8 +103,7 @@ class FrameworkBuilderI {
   virtual auto BuildDriftDiffusionFormulation(
       const std::shared_ptr<AngularFluxIntegrator>&,
       const std::shared_ptr<FiniteElement>&,
-      const std::shared_ptr<data::CrossSections>&,
-      const std::shared_ptr<QuadratureSet>) -> std::unique_ptr<DriftDiffusionFormulation> = 0;
+      const std::shared_ptr<data::CrossSections>&) -> std::unique_ptr<DriftDiffusionFormulation> = 0;
   virtual auto BuildDomain(const FrameworkParameters::DomainSize,
                            const FrameworkParameters::NumberOfCells,
                            const std::shared_ptr<FiniteElement>&,

--- a/src/framework/builder/framework_builder_i.hpp
+++ b/src/framework/builder/framework_builder_i.hpp
@@ -30,6 +30,7 @@
 #include "quadrature/quadrature_set_i.h"
 #include "problem/parameter_types.h"
 #include "solver/group/single_group_solver_i.h"
+#include "system/moments/spherical_harmonic_i.h"
 #include "system/moments/spherical_harmonic_types.h"
 #include "system/solution/solution_types.h"
 #include "system/system.h"
@@ -59,6 +60,7 @@ class FrameworkBuilderI {
   using ParameterConvergenceChecker = convergence::FinalI<double>;
   using QuadratureSet = typename quadrature::QuadratureSetI<dim>;
   using SAAFFormulation = typename formulation::angular::SelfAdjointAngularFluxI<dim>;
+  using SphericalHarmonicMoments = system::moments::SphericalHarmonicI;
   using SingleGroupSolver = solver::group::SingleGroupSolverI;
   using Stamper = formulation::StamperI<dim>;
   using System = system::System;
@@ -160,6 +162,14 @@ class FrameworkBuilderI {
                            const std::size_t solution_size,
                            bool is_eigenvalue_problem,
                            bool need_rhs_boundary_condition) -> std::unique_ptr<System> = 0;
+
+  virtual auto BuildUpdaterPointers(std::unique_ptr<DiffusionFormulation>,
+                                    std::unique_ptr<DriftDiffusionFormulation>,
+                                    std::shared_ptr<Stamper>,
+                                    std::shared_ptr<AngularFluxIntegrator>,
+                                    std::shared_ptr<SphericalHarmonicMoments>,
+                                    AngularFluxStorage&,
+                                    const std::map<problem::Boundary, bool>&) -> UpdaterPointers = 0;
   virtual auto BuildUpdaterPointers(std::unique_ptr<DiffusionFormulation>,
                                     std::unique_ptr<Stamper>,
                                     const std::map<problem::Boundary, bool>&) -> UpdaterPointers = 0;

--- a/src/framework/builder/framework_builder_i.hpp
+++ b/src/framework/builder/framework_builder_i.hpp
@@ -26,6 +26,7 @@
 #include "iteration/group/group_solve_iteration_i.h"
 #include "iteration/outer/outer_iteration_i.hpp"
 #include "quadrature/calculators/spherical_harmonic_moments_i.h"
+#include "quadrature/calculators/angular_flux_integrator_i.hpp"
 #include "quadrature/quadrature_set_i.h"
 #include "problem/parameter_types.h"
 #include "solver/group/single_group_solver_i.h"
@@ -40,6 +41,7 @@ template <int dim>
 class FrameworkBuilderI {
  public:
   // Classes built by member functions
+  using AngularFluxIntegrator = quadrature::calculators::AngularFluxIntegratorI;
   using CrossSections = data::CrossSections;
   using DiffusionFormulation = typename formulation::scalar::DiffusionI<dim>;
   using DriftDiffusionFormulation = typename formulation::scalar::DriftDiffusionI<dim>;
@@ -90,6 +92,8 @@ class FrameworkBuilderI {
 
   virtual ~FrameworkBuilderI() = default;
 
+  virtual auto BuildAngularFluxIntegrator(
+      const std::shared_ptr<QuadratureSet>) -> std::unique_ptr<AngularFluxIntegrator> = 0;
   virtual auto BuildDiffusionFormulation(
       const std::shared_ptr<FiniteElement>&,
       const std::shared_ptr<data::CrossSections>&,

--- a/src/framework/builder/tests/framework_builder_integration_tests.cpp
+++ b/src/framework/builder/tests/framework_builder_integration_tests.cpp
@@ -238,7 +238,15 @@ TYPED_TEST(FrameworkBuilderIntegrationTest, Constructor) {
 
 // =============================================================================
 
+TYPED_TEST(FrameworkBuilderIntegrationTest, BuildAngularFluxIntegratorTest) {
+  constexpr int dim = this->dim;
+  auto angular_flux_integrator_ptr = this->test_builder_ptr_->BuildAngularFluxIntegrator(this->quadrature_set_sptr_);
 
+  using ExpectedType = typename quadrature::calculators::AngularFluxIntegrator<dim>;
+  auto dynamic_ptr = dynamic_cast<ExpectedType*>(angular_flux_integrator_ptr.get());
+  ASSERT_NE(nullptr, dynamic_ptr);
+  EXPECT_EQ(dynamic_ptr->quadrature_set_ptr(), this->quadrature_set_sptr_.get());
+}
 
 TYPED_TEST(FrameworkBuilderIntegrationTest, BuildDiffusionFormulationTest) {
   constexpr int dim = this->dim;

--- a/src/framework/builder/tests/framework_builder_integration_tests.cpp
+++ b/src/framework/builder/tests/framework_builder_integration_tests.cpp
@@ -291,8 +291,7 @@ TYPED_TEST(FrameworkBuilderIntegrationTest, BuildDriftDiffusionFormulationTest) 
   auto drift_diffusion_formulation_ptr = this->test_builder_ptr_->BuildDriftDiffusionFormulation(
       this->angular_flux_integrator_sptr_,
       this->finite_element_sptr_,
-      this->cross_sections_sptr_,
-      this->quadrature_set_sptr_);
+      this->cross_sections_sptr_);
 
   using Formulation = formulation::scalar::DriftDiffusion<dim>;
   using DriftDiffusionCalculator = calculator::drift_diffusion::DriftDiffusionVectorCalculator<dim>;

--- a/src/framework/builder/tests/framework_builder_mock.hpp
+++ b/src/framework/builder/tests/framework_builder_mock.hpp
@@ -7,8 +7,9 @@
 namespace bart::framework::builder {
 
 template <int dim>
-class FrameworkBuilderMock : public FrameworkBuilderI<dim> {
+class FrameworkBuilderMock : public FrameworkBuilderI<dim>     {
  public:
+  using typename FrameworkBuilderI<dim>::AngularFluxIntegrator;
   using typename FrameworkBuilderI<dim>::CrossSections;
   using typename FrameworkBuilderI<dim>::DiffusionFormulation;
   using typename FrameworkBuilderI<dim>::DriftDiffusionFormulation;
@@ -45,7 +46,8 @@ class FrameworkBuilderMock : public FrameworkBuilderI<dim> {
   using typename FrameworkBuilderI<dim>::ConvergenceInstrument;
   using typename FrameworkBuilderI<dim>::StatusInstrument;
 
-
+  MOCK_METHOD(std::unique_ptr<AngularFluxIntegrator>, BuildAngularFluxIntegrator,
+              (const std::shared_ptr<QuadratureSet>), (override));
   MOCK_METHOD(std::unique_ptr<DiffusionFormulation>, BuildDiffusionFormulation,
       (const std::shared_ptr<FiniteElement>&, const std::shared_ptr<data::CrossSections>&,
       const DiffusionFormulationImpl), (override));

--- a/src/framework/builder/tests/framework_builder_mock.hpp
+++ b/src/framework/builder/tests/framework_builder_mock.hpp
@@ -54,7 +54,7 @@ class FrameworkBuilderMock : public FrameworkBuilderI<dim>     {
       const DiffusionFormulationImpl), (override));
   MOCK_METHOD(std::unique_ptr<DriftDiffusionFormulation>, BuildDriftDiffusionFormulation,
   (const std::shared_ptr<AngularFluxIntegrator>&, const std::shared_ptr<FiniteElement>&,
-      const std::shared_ptr<data::CrossSections>&, const std::shared_ptr<QuadratureSet>), (override));
+      const std::shared_ptr<data::CrossSections>&), (override));
   MOCK_METHOD(std::unique_ptr<Domain>, BuildDomain, (const FrameworkParameters::DomainSize,
       const FrameworkParameters::NumberOfCells, const std::shared_ptr<FiniteElement>&,
       const std::string material_mapping), (override));

--- a/src/framework/builder/tests/framework_builder_mock.hpp
+++ b/src/framework/builder/tests/framework_builder_mock.hpp
@@ -52,8 +52,8 @@ class FrameworkBuilderMock : public FrameworkBuilderI<dim>     {
       (const std::shared_ptr<FiniteElement>&, const std::shared_ptr<data::CrossSections>&,
       const DiffusionFormulationImpl), (override));
   MOCK_METHOD(std::unique_ptr<DriftDiffusionFormulation>, BuildDriftDiffusionFormulation,
-  (const std::shared_ptr<FiniteElement>&, const std::shared_ptr<data::CrossSections>&,
-      const std::shared_ptr<QuadratureSet>), (override));
+  (const std::shared_ptr<AngularFluxIntegrator>&, const std::shared_ptr<FiniteElement>&,
+      const std::shared_ptr<data::CrossSections>&, const std::shared_ptr<QuadratureSet>), (override));
   MOCK_METHOD(std::unique_ptr<Domain>, BuildDomain, (const FrameworkParameters::DomainSize,
       const FrameworkParameters::NumberOfCells, const std::shared_ptr<FiniteElement>&,
       const std::string material_mapping), (override));

--- a/src/framework/builder/tests/framework_builder_mock.hpp
+++ b/src/framework/builder/tests/framework_builder_mock.hpp
@@ -11,6 +11,7 @@ class FrameworkBuilderMock : public FrameworkBuilderI<dim> {
  public:
   using typename FrameworkBuilderI<dim>::CrossSections;
   using typename FrameworkBuilderI<dim>::DiffusionFormulation;
+  using typename FrameworkBuilderI<dim>::DriftDiffusionFormulation;
   using typename FrameworkBuilderI<dim>::Domain;
   using typename FrameworkBuilderI<dim>::FiniteElement;
   using typename FrameworkBuilderI<dim>::FrameworkI;
@@ -48,6 +49,9 @@ class FrameworkBuilderMock : public FrameworkBuilderI<dim> {
   MOCK_METHOD(std::unique_ptr<DiffusionFormulation>, BuildDiffusionFormulation,
       (const std::shared_ptr<FiniteElement>&, const std::shared_ptr<data::CrossSections>&,
       const DiffusionFormulationImpl), (override));
+  MOCK_METHOD(std::unique_ptr<DriftDiffusionFormulation>, BuildDriftDiffusionFormulation,
+  (const std::shared_ptr<FiniteElement>&, const std::shared_ptr<data::CrossSections>&,
+      const std::shared_ptr<QuadratureSet>), (override));
   MOCK_METHOD(std::unique_ptr<Domain>, BuildDomain, (const FrameworkParameters::DomainSize,
       const FrameworkParameters::NumberOfCells, const std::shared_ptr<FiniteElement>&,
       const std::string material_mapping), (override));

--- a/src/framework/builder/tests/framework_builder_mock.hpp
+++ b/src/framework/builder/tests/framework_builder_mock.hpp
@@ -27,6 +27,7 @@ class FrameworkBuilderMock : public FrameworkBuilderI<dim>     {
   using typename FrameworkBuilderI<dim>::ParameterConvergenceChecker;
   using typename FrameworkBuilderI<dim>::QuadratureSet;
   using typename FrameworkBuilderI<dim>::SAAFFormulation;
+  using typename FrameworkBuilderI<dim>::SphericalHarmonicMoments;
   using typename FrameworkBuilderI<dim>::SingleGroupSolver;
   using typename FrameworkBuilderI<dim>::Stamper;
   using typename FrameworkBuilderI<dim>::System;
@@ -88,6 +89,9 @@ class FrameworkBuilderMock : public FrameworkBuilderI<dim>     {
   MOCK_METHOD(std::unique_ptr<Stamper>, BuildStamper, (const std::shared_ptr<Domain>&), (override));
   MOCK_METHOD(std::unique_ptr<System>, BuildSystem, (const int, const int, const Domain&,
       const std::size_t solution_size, bool is_eigenvalue_problem, bool need_rhs_boundary_condition), (override));
+  MOCK_METHOD(UpdaterPointers, BuildUpdaterPointers, (std::unique_ptr<DiffusionFormulation>,
+      std::unique_ptr<DriftDiffusionFormulation>, std::shared_ptr<Stamper>, std::shared_ptr<AngularFluxIntegrator>,
+      std::shared_ptr<SphericalHarmonicMoments>, AngularFluxStorage&, (const std::map<problem::Boundary, bool>&)),(override));
   MOCK_METHOD(UpdaterPointers, BuildUpdaterPointers, (std::unique_ptr<DiffusionFormulation>,
       std::unique_ptr<Stamper>, (const std::map<problem::Boundary, bool>&)), (override));
   MOCK_METHOD(UpdaterPointers, BuildUpdaterPointers, (std::unique_ptr<SAAFFormulation>,

--- a/src/quadrature/calculators/angular_flux_integrator.cpp
+++ b/src/quadrature/calculators/angular_flux_integrator.cpp
@@ -1,4 +1,5 @@
 #include "quadrature/calculators/angular_flux_integrator.hpp"
+#include "quadrature/calculators/quadrature_calculators_factories.hpp"
 
 namespace bart::quadrature::calculators {
 
@@ -7,6 +8,13 @@ AngularFluxIntegrator<dim>::AngularFluxIntegrator(std::shared_ptr<QuadratureSet>
     : quadrature_set_ptr_(quadrature_set_ptr) {
   this->AssertPointerNotNull(quadrature_set_ptr_.get(), "quadrature set", "DriftDiffusionIntegratedFlux constructor");
 }
+
+template<int dim>
+bool AngularFluxIntegrator<dim>::is_registered_ =
+    AngularFluxIntegrator<dim>::Factory::get().RegisterConstructor(
+        AngularFluxIntegratorName::kDefaultImplementation,
+        [](std::shared_ptr<QuadratureSet> quadrature_set_ptr) -> std::unique_ptr<AngularFluxIntegratorI> {
+          return std::make_unique<AngularFluxIntegrator<dim>>(quadrature_set_ptr); });
 
 template<int dim>
 auto AngularFluxIntegrator<dim>::NetCurrent(const VectorMap& angular_flux_map) const -> std::vector<Vector> {

--- a/src/quadrature/calculators/angular_flux_integrator.hpp
+++ b/src/quadrature/calculators/angular_flux_integrator.hpp
@@ -8,10 +8,13 @@
 
 namespace bart::quadrature::calculators {
 
+template <typename...> class AngularFluxIntegratorIFactory;
+
 template <int dim>
 class AngularFluxIntegrator : public AngularFluxIntegratorI, public utility::HasDependencies {
  public:
   using QuadratureSet = typename quadrature::QuadratureSetI<dim>;
+  using Factory = AngularFluxIntegratorIFactory<std::shared_ptr<QuadratureSet>>;
 
   AngularFluxIntegrator(std::shared_ptr<QuadratureSet>);
 
@@ -24,8 +27,10 @@ class AngularFluxIntegrator : public AngularFluxIntegratorI, public utility::Has
 
   auto quadrature_set_ptr() const -> QuadratureSet* { return quadrature_set_ptr_.get(); }
 
- private:
+ protected:
   std::shared_ptr<QuadratureSet> quadrature_set_ptr_{ nullptr };
+ private:
+  static bool is_registered_;
 };
 
 } // namespace bart::quadrature::calculators

--- a/src/quadrature/calculators/quadrature_calculators_factories.hpp
+++ b/src/quadrature/calculators/quadrature_calculators_factories.hpp
@@ -1,0 +1,20 @@
+#ifndef BART_SRC_QUADRATURE_CALCULATORS_QUADRATURE_CALCULATORS_FACTORIES_HPP_
+#define BART_SRC_QUADRATURE_CALCULATORS_QUADRATURE_CALCULATORS_FACTORIES_HPP_
+
+#include "utility/factory/auto_registering_factory.hpp"
+
+namespace bart::quadrature::calculators {
+
+class AngularFluxIntegratorI;
+
+enum class AngularFluxIntegratorName { kDefaultImplementation = 0 };
+
+template <typename...T>
+class AngularFluxIntegratorIFactory : public utility::factory::AutoRegisteringFactory<
+    AngularFluxIntegratorName,
+    std::unique_ptr<AngularFluxIntegratorI>(*)(T...)> {};
+
+} // namespace bart::quadrature::calculators
+
+
+#endif //BART_SRC_QUADRATURE_CALCULATORS_QUADRATURE_CALCULATORS_FACTORIES_HPP_

--- a/src/utility/tests/to_string_test.cpp
+++ b/src/utility/tests/to_string_test.cpp
@@ -20,17 +20,23 @@ using OutstreamName = bart::instrumentation::outstream::OutstreamName;
 using GroupSolverName = bart::solver::group::GroupSolverName;
 using LinearSolverName = bart::solver::linear::LinearSolverName;
 
+struct NoStringConversionType{};
+
 template <typename T>
 class UtilityToStringTest : public ::testing::Test {
  public:
   [[nodiscard]] auto GetValue() const -> T;
 };
 
-using TestTypes = ::testing::Types<int, double, ConverterName, MeshName, OutstreamName, GroupSolverName, LinearSolverName>;
+using TestTypes = ::testing::Types<int, double, ConverterName, MeshName, OutstreamName, GroupSolverName, LinearSolverName, NoStringConversionType>;
 TYPED_TEST_SUITE(UtilityToStringTest, TestTypes);
 
 template <>
 auto UtilityToStringTest<int>::GetValue() const -> int { return test_helpers::RandomInt(-100, 100); }
+
+template <>
+auto UtilityToStringTest<NoStringConversionType>::GetValue() const -> NoStringConversionType {
+  return NoStringConversionType(); }
 
 template <>
 auto UtilityToStringTest<double>::GetValue() const -> double { return test_helpers::RandomDouble(-100, 100); }

--- a/src/utility/to_string.hpp
+++ b/src/utility/to_string.hpp
@@ -11,6 +11,8 @@ inline auto to_string(T to_convert) {
     return std::to_string(to_convert);
   } else if constexpr (requires { to_string(to_convert); }) {
     return to_string(to_convert);
+  } else {
+    return std::string{"<no conversion to string>"};
   }
 }
 


### PR DESCRIPTION
This updated adds factories for various drift-diffusion classes and support classes, as well as functions to use these factories to the `FrameworkBuilder` class.