### PR TITLE
NDA convergence iteration number fix

### DIFF
--- a/benchmarks/picca_2016/multi_slab/multi_slab_rayleigh_nda.prm
+++ b/benchmarks/picca_2016/multi_slab/multi_slab_rayleigh_nda.prm
@@ -14,7 +14,7 @@ set number of materials                      = 2
 set finite element polynomial degree         = 1
 set k_effective updater type                 = rayleigh quotient
 
-set output file name base                    = multi_slab_rayleigh
+set output file name base                    = multi_slab_rayleigh_nda
 set do nda                                   = true
 
 subsection material ID map

--- a/src/iteration/outer/outer_iteration.cpp
+++ b/src/iteration/outer/outer_iteration.cpp
@@ -9,20 +9,17 @@ OuterIteration<ConvergenceType>::OuterIteration(std::unique_ptr<GroupIterator> g
                                                 std::unique_ptr<ConvergenceChecker> convergence_checker_ptr)
     : group_iterator_ptr_(std::move(group_iterator_ptr)),
       convergence_checker_ptr_(std::move(convergence_checker_ptr)) {
-
   AssertThrow(group_iterator_ptr_ != nullptr,
-              dealii::ExcMessage("GroupSolveIteration pointer passed to "
-                                 "OuterIteration constructor is null"))
+              dealii::ExcMessage("GroupSolveIteration pointer passed to OuterIteration constructor is null"))
 
   AssertThrow(convergence_checker_ptr_ != nullptr,
-              dealii::ExcMessage("Convergence checker pointer passed to "
-                                 "OuterIteration constructor is null"))
+              dealii::ExcMessage("Convergence checker pointer passed to OuterIteration constructor is null"))
 }
 
 template <typename ConvergenceType>
-void OuterIteration<ConvergenceType>::IterateToConvergence(
-    system::System &system) {
+void OuterIteration<ConvergenceType>::IterateToConvergence(system::System &system) {
   bool is_complete{ false };
+  this->convergence_checker_ptr_->Reset();
   do {
     is_complete = Iterate(system);
     if (post_iteration_subroutine_ptr_ != nullptr) {
@@ -34,8 +31,7 @@ void OuterIteration<ConvergenceType>::IterateToConvergence(
 }
 
 template <typename ConvergenceType>
-void OuterIteration<ConvergenceType>::InnerIterationToConvergence(
-    system::System &system) {
+void OuterIteration<ConvergenceType>::InnerIterationToConvergence(system::System &system) {
   group_iterator_ptr_->Iterate(system);
 }
 

--- a/src/iteration/outer/tests/outer_fixed_source_iteration_test.cpp
+++ b/src/iteration/outer/tests/outer_fixed_source_iteration_test.cpp
@@ -70,6 +70,7 @@ TEST_F(IterationOuterFixedSourceIterationTest, Constructor) {
 
 /* Call to Iterate() should mediate the dependencies properly */
 TEST_F(IterationOuterFixedSourceIterationTest, Iterate) {
+  EXPECT_CALL(*convergence_checker_mock_obs_ptr_, Reset());
   EXPECT_CALL(*group_iterator_mock_obs_ptr_, Iterate(Ref(test_system))).Times(1);
   EXPECT_CALL(*convergence_status_instrument_ptr_, Read(_));
   EXPECT_CALL(*status_instrument_ptr_, Read(_));

--- a/src/iteration/outer/tests/outer_fixed_source_iteration_test.cpp
+++ b/src/iteration/outer/tests/outer_fixed_source_iteration_test.cpp
@@ -12,6 +12,12 @@ namespace  {
 using namespace bart;
 using ::testing::A, ::testing::Ref, ::testing::_;
 
+/* This fixture tests the operation of the OuterFixedSourceIteration class. This is a mediator class so the tests will verify
+ * proper mediation between the dependencies and exposure of data to instruments.
+ *
+ * At the completion of SetUp() the test_iterator pointee object is set up with mock dependencies accessible via
+ * the provided observation pointers. Mock instrumentation is accessible via shared pointers.
+ * */
 class IterationOuterFixedSourceIterationTest : public ::testing::Test {
  public:
   using TestIterationType = iteration::outer::OuterFixedSourceIteration;
@@ -22,11 +28,11 @@ class IterationOuterFixedSourceIterationTest : public ::testing::Test {
   using StatusInstrumentType = instrumentation::InstrumentMock<std::string>;
 
   // Test object
-  std::unique_ptr<TestIterationType> test_iterator = nullptr;
+  std::unique_ptr<TestIterationType> test_iterator{ nullptr };
 
   // Mock instruments
-  std::shared_ptr<ConvergenceInstrumentType> convergence_status_instrument_ptr_;
-  std::shared_ptr<StatusInstrumentType> status_instrument_ptr_;
+  std::shared_ptr<ConvergenceInstrumentType> convergence_status_instrument_ptr_ { std::make_shared<ConvergenceInstrumentType>() };
+  std::shared_ptr<StatusInstrumentType> status_instrument_ptr_{ std::make_shared<StatusInstrumentType>() };
 
   // Observation pointers
   GroupIteratorType* group_iterator_mock_obs_ptr_;
@@ -43,8 +49,6 @@ void IterationOuterFixedSourceIterationTest::SetUp() {
   group_iterator_mock_obs_ptr_ = group_iterator_ptr.get();
   auto convergence_checker_ptr = std::make_unique<ConvergenceCheckerType>();
   convergence_checker_mock_obs_ptr_ = convergence_checker_ptr.get();
-  convergence_status_instrument_ptr_ = std::make_shared<ConvergenceInstrumentType>();
-  status_instrument_ptr_ = std::make_shared<StatusInstrumentType>();
 
   test_iterator = std::make_unique<TestIterationType>(std::move(group_iterator_ptr),
                                                       std::move(convergence_checker_ptr));
@@ -57,12 +61,14 @@ void IterationOuterFixedSourceIterationTest::SetUp() {
   instrumentation::GetPort<StatusPort>(*test_iterator).AddInstrument(status_instrument_ptr_);
 }
 
+/* Constructor should not throw when valid dependency pointers are passed */
 TEST_F(IterationOuterFixedSourceIterationTest, Constructor) {
   EXPECT_NO_THROW({
     TestIterationType test_iterator(std::make_unique<GroupIteratorType>(),std::make_unique<ConvergenceCheckerType>());
   });
 }
 
+/* Call to Iterate() should mediate the dependencies properly */
 TEST_F(IterationOuterFixedSourceIterationTest, Iterate) {
   EXPECT_CALL(*group_iterator_mock_obs_ptr_, Iterate(Ref(test_system))).Times(1);
   EXPECT_CALL(*convergence_status_instrument_ptr_, Read(_));
@@ -70,6 +76,7 @@ TEST_F(IterationOuterFixedSourceIterationTest, Iterate) {
   test_iterator->IterateToConvergence(this->test_system);
 }
 
+/* Call to UpdateSystem() should do nothing */
 TEST_F(IterationOuterFixedSourceIterationTest, Update) {
   test_iterator->UpdateSystem(this->test_system, test_helpers::RandomInt(0, 10), test_helpers::RandomInt(0, 10));
 }

--- a/src/iteration/outer/tests/outer_power_iteration_test.cpp
+++ b/src/iteration/outer/tests/outer_power_iteration_test.cpp
@@ -169,17 +169,12 @@ TEST_F(IterationOuterPowerIterationTest, IterateToConvergenceTest) {
         .WillOnce(Return(convergence_status));
   }
 
-  EXPECT_CALL(*this->group_iterator_obs_ptr_, Iterate(Ref(this->test_system)))
-      .Times(this->iterations_);
-
-  EXPECT_CALL(*this->convergence_instrument_ptr_, Read(_))
-      .Times(this->iterations_);
-  EXPECT_CALL(*this->post_iteration_subroutine_obs_ptr_, Execute(Ref(this->test_system)))
-      .Times(this->iterations_);
-  EXPECT_CALL(*this->status_instrument_ptr_, Read(_))
-      .Times(AtLeast(this->iterations_));
-  EXPECT_CALL(*this->error_instrument_ptr_, Read(_))
-      .Times(this->iterations_ - 1);
+  EXPECT_CALL(*this->convergence_checker_obs_ptr_, Reset());
+  EXPECT_CALL(*this->group_iterator_obs_ptr_, Iterate(Ref(this->test_system))).Times(this->iterations_);
+  EXPECT_CALL(*this->convergence_instrument_ptr_, Read(_)).Times(this->iterations_);
+  EXPECT_CALL(*this->post_iteration_subroutine_obs_ptr_, Execute(Ref(this->test_system))).Times(this->iterations_);
+  EXPECT_CALL(*this->status_instrument_ptr_, Read(_)).Times(AtLeast(this->iterations_));
+  EXPECT_CALL(*this->error_instrument_ptr_, Read(_)).Times(this->iterations_ - 1);
 
   this->test_iterator->IterateToConvergence(this->test_system);
 }


### PR DESCRIPTION
This PR adds a call to `ConvergenceCheckerI::Reset()` at the start of each call to `OuterIteration::Iterate()` to reset the convergence properties. This is important for subroutines like NDA that will start a new framework solve every time it is called.

Also includes minor formatting and documentation fixes.

Closes #212.