### PR TITLE
Instrumentation update

### DIFF
--- a/src/framework/framework_helper.cpp
+++ b/src/framework/framework_helper.cpp
@@ -484,13 +484,14 @@ auto FrameworkHelper<dim>::BuildFramework(
   }
   if (parameters.output_fission_source_as_vtu) {
     try {
-      auto fission_source_vector_to_vtu_instrument =
-          std::make_shared<instrumentation::BasicInstrument<dealii::Vector<double>>>(
-              std::make_unique<typename instrumentation::outstream::VectorToVTU<dim>>(domain_ptr,
-                                                                                      "fission_source",
-                                                                                      "fission_source",
-                                                                                      parameters.output_filename_base
-                                                                                          + "_fission_source"));
+      using VectorMap = std::unordered_map<int, dealii::Vector<double>>;
+      using VectorMapInstrument = instrumentation::BasicInstrument<VectorMap>;
+      using VectorMapOutstream = typename instrumentation::outstream::VectorMapToVTU<dim>;
+      std::string filename_base{ parameters.output_filename_base + "_fission_source" };
+
+      auto fission_source_vector_to_vtu_instrument = std::make_shared<VectorMapInstrument>(
+          std::make_unique<VectorMapOutstream>(domain_ptr, "fission_source",filename_base + "/outer_iteration",
+                                               filename_base));
       instrumentation::GetPort<iteration::outer::data_names::FissionSourcePort>(*outer_iteration_ptr)
           .AddInstrument(fission_source_vector_to_vtu_instrument);
     } catch (std::bad_cast &) {

--- a/src/framework/framework_helper.cpp
+++ b/src/framework/framework_helper.cpp
@@ -499,12 +499,12 @@ auto FrameworkHelper<dim>::BuildFramework(
   }
   if (parameters.output_scalar_flux_as_vtu) {
     try {
-      auto scalar_flux_to_vtu_instrument = std::make_shared<instrumentation::BasicInstrument<dealii::Vector<double>>>(
-          std::make_unique<typename instrumentation::outstream::VectorToVTU<dim>>(domain_ptr,
-                                                                                  "scalar_flux",
-                                                                                  "scalar_flux",
-                                                                                  parameters.output_filename_base
-                                                                                      + "_scalar_flux"));
+      using VectorMap = std::unordered_map<int, dealii::Vector<double>>;
+      using VectorMapInstrument = instrumentation::BasicInstrument<VectorMap>;
+      using VectorMapOutstream = typename instrumentation::outstream::VectorMapToVTU<dim>;
+      std::string filename_base{ parameters.output_filename_base + "_scalar_flux" };
+      auto scalar_flux_to_vtu_instrument = std::make_shared<VectorMapInstrument>(std::make_unique<VectorMapOutstream>(
+          domain_ptr, "scalar_flux", filename_base + "/outer_iteration", filename_base));
       instrumentation::GetPort<iteration::outer::data_names::ScalarFluxPort>(*outer_iteration_ptr)
           .AddInstrument(scalar_flux_to_vtu_instrument);
     } catch (std::bad_cast &) {

--- a/src/instrumentation/outstream/tests/vector_map_to_vtu_test.cpp
+++ b/src/instrumentation/outstream/tests/vector_map_to_vtu_test.cpp
@@ -1,0 +1,64 @@
+#include "instrumentation/outstream/vector_map_to_vtu.hpp"
+
+#include <filesystem>
+
+#include "domain/tests/domain_mock.hpp"
+#include "test_helpers/dealii_test_domain.h"
+#include "test_helpers/gmock_wrapper.h"
+
+namespace  {
+
+using namespace bart;
+
+template <typename DimensionWrapper>
+class InstrumentationOutstreamVectorMapToVtuTest : public ::testing::Test,
+                                                public bart::testing::DealiiTestDomain<DimensionWrapper::value> {
+ public:
+  static constexpr int dim = DimensionWrapper::value;
+  using Domain = domain::DomainMock<dim>;
+
+  std::shared_ptr<Domain> domain_ptr_{ std::make_shared<Domain>() };
+  const std::string data_name{ "data_vector" };
+  const std::string directory{ "test_output_directory" };
+  const std::string filename_base{ "filename_base" };
+
+  auto SetUp() -> void override { this->SetUpDealii(); };
+};
+
+TYPED_TEST_SUITE(InstrumentationOutstreamVectorMapToVtuTest, bart::testing::AllDimensions);
+
+TYPED_TEST(InstrumentationOutstreamVectorMapToVtuTest, Constructor) {
+  constexpr int dim = this->dim;
+  instrumentation::outstream::VectorMapToVTU<dim> test_outstream(this->domain_ptr_, this->data_name, this->directory,
+                                                                 this->filename_base);
+  EXPECT_NE(test_outstream.definition_ptr(), nullptr);
+  EXPECT_EQ(test_outstream.data_name(), this->data_name);
+  EXPECT_EQ(test_outstream.directory(), this->directory);
+  EXPECT_EQ(test_outstream.filename_base(), this->filename_base);
+}
+
+TYPED_TEST(InstrumentationOutstreamVectorMapToVtuTest, Output) {
+  constexpr int dim = this->dim;
+  namespace fs = std::filesystem;
+
+  instrumentation::outstream::VectorMapToVTU<dim> test_outstream(this->domain_ptr_, this->data_name, this->directory,
+                                                                 this->filename_base);
+
+  EXPECT_CALL(*this->domain_ptr_, dof_handler()).WillOnce(::testing::ReturnRef(this->dof_handler_));
+
+  std::unordered_map<int, dealii::Vector<double>> vector_map;
+  const int total_groups{ 10 };
+  for (int group = 0; group < total_groups; ++group) {
+    vector_map[group] = dealii::Vector<double>(this->dof_handler_.n_dofs());
+  }
+
+  test_outstream.Output(vector_map);
+  std::string filename{ this->directory + "/" + this->filename_base + "_0000"};
+  EXPECT_TRUE(fs::exists(filename + ".0.vtu"));
+  EXPECT_TRUE(fs::exists(filename + ".pvtu"));
+  fs::remove_all(this->directory);
+}
+
+
+
+} // namespace

--- a/src/instrumentation/outstream/tests/vector_to_vtu_test.cpp
+++ b/src/instrumentation/outstream/tests/vector_to_vtu_test.cpp
@@ -48,7 +48,6 @@ TYPED_TEST(InstrumentationOutstreamVectorToVtuTest, Constructor) {
 TYPED_TEST(InstrumentationOutstreamVectorToVtuTest, Output) {
   constexpr int dim = this->dim;
   namespace fs = std::filesystem;
-  fs::create_directory(this->directory);
 
   instrumentation::outstream::VectorToVTU<dim> test_outstream(this->domain_ptr_, this->data_name, this->directory,
                                                               this->filename_base);

--- a/src/instrumentation/outstream/vector_map_to_vtu.cpp
+++ b/src/instrumentation/outstream/vector_map_to_vtu.cpp
@@ -1,0 +1,38 @@
+#include "instrumentation/outstream/vector_map_to_vtu.hpp"
+
+#include <filesystem>
+
+namespace bart::instrumentation::outstream {
+
+template<int dim>
+VectorMapToVTU<dim>::VectorMapToVTU(std::shared_ptr<Definition> definition_ptr,
+                                    const std::string data_name,
+                                    const std::string directory,
+                                    const std::string filename_base)
+    : definition_ptr_(definition_ptr), data_name_(data_name), directory_(directory), filename_base_(filename_base) {}
+
+template<int dim>
+auto VectorMapToVTU<dim>::Output(const VectorMap& to_output) -> VectorMapToVTU& {
+  dealii::DataOut<dim> data_out;
+
+  data_out.attach_dof_handler(definition_ptr_->dof_handler());
+
+  for (const auto& [group, vector] : to_output) {
+    std::string vector_name{ data_name_ + "_group_" + std::to_string(group) };
+    data_out.add_data_vector(vector, vector_name);
+  }
+  data_out.build_patches();
+
+  if (!std::filesystem::exists(directory_)) {
+    std::filesystem::create_directories(directory_);
+  }
+  data_out.write_vtu_with_pvtu_record(directory_ + "/", filename_base_, counter_, MPI_COMM_WORLD, 4);
+  ++counter_;
+  return *this;
+}
+
+template class VectorMapToVTU<1>;
+template class VectorMapToVTU<2>;
+template class VectorMapToVTU<3>;
+
+} // namespace bart::instrumentation::outstream

--- a/src/instrumentation/outstream/vector_map_to_vtu.hpp
+++ b/src/instrumentation/outstream/vector_map_to_vtu.hpp
@@ -1,0 +1,42 @@
+#ifndef BART_SRC_INSTRUMENTATION_OUTSTREAM_VECTOR_MAP_TO_VTU_HPP_
+#define BART_SRC_INSTRUMENTATION_OUTSTREAM_VECTOR_MAP_TO_VTU_HPP_
+
+#include <memory>
+#include <unordered_map>
+
+#include <deal.II/lac/vector.h>
+#include <deal.II/numerics/data_out.h>
+
+#include "domain/domain_i.hpp"
+#include "instrumentation/outstream/outstream_i.h"
+#include "instrumentation/outstream/factory.hpp"
+
+namespace bart::instrumentation::outstream {
+
+template <int dim>
+class VectorMapToVTU : public OutstreamI<std::unordered_map<int, dealii::Vector<double>>> {
+ public:
+  using Vector = dealii::Vector<double>;
+  using Definition = domain::DomainI<dim>;
+  using VectorMap = std::unordered_map<int, Vector>;
+
+  VectorMapToVTU(std::shared_ptr<Definition>, std::string data_name, std::string directory, std::string filename_base);
+  auto Output(const VectorMap& to_output) -> VectorMapToVTU& override;
+
+  auto definition_ptr() const { return definition_ptr_.get(); }
+  auto data_name() const { return data_name_; }
+  auto directory() const { return directory_; }
+  auto filename_base() const { return filename_base_; }
+ private:
+  std::shared_ptr<Definition> definition_ptr_{ nullptr };
+  const std::string data_name_;
+  const std::string directory_;
+  const std::string filename_base_;
+
+  int counter_{ 0 };
+  static bool is_registered_;
+};
+
+} // namespace bart::instrumentation::outstream
+
+#endif //BART_SRC_INSTRUMENTATION_OUTSTREAM_VECTOR_MAP_TO_VTU_HPP_

--- a/src/instrumentation/outstream/vector_to_vtu.cpp
+++ b/src/instrumentation/outstream/vector_to_vtu.cpp
@@ -1,5 +1,7 @@
 #include "instrumentation/outstream/vector_to_vtu.hpp"
 
+#include <filesystem>
+
 namespace bart::instrumentation::outstream {
 
 template<int dim>
@@ -22,9 +24,14 @@ bool VectorToVTU<dim>::is_registered_ = Factory::get()
 template <int dim>
 auto VectorToVTU<dim>::Output(const Vector& to_output) -> VectorToVTU& {
   dealii::DataOut<dim> data_out;
+
   data_out.attach_dof_handler(definition_ptr_->dof_handler());
   data_out.add_data_vector(to_output, data_name_);
   data_out.build_patches();
+
+  if (!std::filesystem::exists(directory_)) {
+    std::filesystem::create_directories(directory_);
+  }
   data_out.write_vtu_with_pvtu_record(directory_ + "/", filename_base_, counter_, MPI_COMM_WORLD, 4);
   ++counter_;
   return *this;

--- a/src/iteration/group/group_solve_iteration.cpp
+++ b/src/iteration/group/group_solve_iteration.cpp
@@ -90,6 +90,19 @@ auto GroupSolveIteration<dim>::Iterate(System &system) -> void {
               system.current_moments->moments(), previous_moments_map);
       data_ports::StatusPort::Expose("....All group convergence: ");
       data_ports::ConvergenceStatusPort::Expose(all_group_convergence_status);
+
+      if (system.right_hand_side_ptr_ != nullptr) {
+        using VariableTerms = system::terms::VariableLinearTerms;
+        auto variable_terms{ system.right_hand_side_ptr_->GetVariableTerms() };
+        if (variable_terms.contains(VariableTerms::kScatteringSource)) {
+          auto scattering_source_ptr =system.right_hand_side_ptr_->GetVariableTermPtr(0, VariableTerms::kScatteringSource);
+          if (scattering_source_ptr != nullptr) {
+            dealii::Vector<double> scattering_source(*scattering_source_ptr);
+            data_ports::ScatteringSourcePort::Expose(scattering_source);
+          }
+        }
+      }
+
     }
   } while(!all_group_convergence_status.is_complete);
   data_ports::NumberOfIterationsPort::Expose(all_group_convergence_status.iteration_number);

--- a/src/iteration/group/group_solve_iteration.hpp
+++ b/src/iteration/group/group_solve_iteration.hpp
@@ -19,11 +19,14 @@ namespace data_ports {
 struct GroupConvergenceStatus;
 struct Status;
 struct NumberOfIterations;
+struct ScatteringSourcePortParameter;
 //! Data port for the status of convergence.
 using ConvergenceStatusPort = instrumentation::Port<convergence::Status, GroupConvergenceStatus>;
 using NumberOfIterationsPort = instrumentation::Port<double, NumberOfIterations>;
 //! Data port for general strings.
 using StatusPort = instrumentation::Port<std::string, Status>;
+//! Scattering source port
+using ScatteringSourcePort = instrumentation::Port<dealii::Vector<double>, ScatteringSourcePortParameter>;
 }
 
 /*! \brief Default implementation for group solve iterations.
@@ -44,7 +47,8 @@ using StatusPort = instrumentation::Port<std::string, Status>;
 template <int dim>
 class GroupSolveIteration : public GroupSolveIterationI, public utility::HasDependencies,
                             public data_ports::ConvergenceStatusPort, public data_ports::StatusPort,
-                            public data_ports::NumberOfIterationsPort {
+                            public data_ports::NumberOfIterationsPort,
+                            public data_ports::ScatteringSourcePort {
  public:
   using GroupSolver = solver::group::SingleGroupSolverI;
   using ConvergenceChecker = convergence::IterationCompletionCheckerI<system::moments::MomentVector>;

--- a/src/iteration/group/group_solve_iteration.hpp
+++ b/src/iteration/group/group_solve_iteration.hpp
@@ -26,7 +26,7 @@ using NumberOfIterationsPort = instrumentation::Port<double, NumberOfIterations>
 //! Data port for general strings.
 using StatusPort = instrumentation::Port<std::string, Status>;
 //! Scattering source port
-using ScatteringSourcePort = instrumentation::Port<dealii::Vector<double>, ScatteringSourcePortParameter>;
+using ScatteringSourcePort = instrumentation::Port<std::unordered_map<int, dealii::Vector<double>>, ScatteringSourcePortParameter>;
 }
 
 /*! \brief Default implementation for group solve iterations.

--- a/src/iteration/outer/outer_iteration.cpp
+++ b/src/iteration/outer/outer_iteration.cpp
@@ -62,7 +62,13 @@ template<typename ConvergenceType>
 auto OuterIteration<ConvergenceType>::ExposeIterationData(system::System &system) -> void {
   if (system.current_moments != nullptr) {
     data_names::SolutionMomentsPort::Expose(*system.current_moments);
-    data_names::ScalarFluxPort::Expose(system.current_moments->GetMoment({0, 0, 0}));
+
+    std::unordered_map<int, dealii::Vector<double>> scalar_flux_map;
+    for (int group = 0; group < system.total_groups; ++group) {
+      scalar_flux_map[group] = dealii::Vector<double>(system.current_moments->GetMoment({group, 0, 0}));
+    }
+
+    data_names::ScalarFluxPort::Expose(scalar_flux_map);
   }
 
   if (system.right_hand_side_ptr_ != nullptr) {

--- a/src/iteration/outer/outer_iteration.hpp
+++ b/src/iteration/outer/outer_iteration.hpp
@@ -22,7 +22,7 @@ using StatusPort = instrumentation::Port<std::string, struct Status>;
 using IterationErrorPort = instrumentation::Port<std::pair<int, double>, struct IterationError>;
 using SolutionMomentsPort = instrumentation::Port<system::moments::SphericalHarmonicI, struct SolutionMoments>;
 using ScatteringSourcePort = instrumentation::Port<dealii::Vector<double>, struct ScatteringSourcePortParameter>;
-using FissionSourcePort = instrumentation::Port<dealii::Vector<double>, struct FissionSourcePortParameter>;
+using FissionSourcePort = instrumentation::Port<GroupVectorMap, struct FissionSourcePortParameter>;
 using ScalarFluxPort = instrumentation::Port<GroupVectorMap, struct ScalarFluxPortParameter>;
 } // namespace data_names
 

--- a/src/iteration/outer/outer_iteration.hpp
+++ b/src/iteration/outer/outer_iteration.hpp
@@ -15,13 +15,15 @@
 namespace bart::iteration::outer {
 
 namespace data_names {
+using GroupVectorMap = std::unordered_map<int, dealii::Vector<double>>;
+
 using ConvergenceStatusPort = instrumentation::Port<convergence::Status, struct GroupConvergenceStatus>;
 using StatusPort = instrumentation::Port<std::string, struct Status>;
 using IterationErrorPort = instrumentation::Port<std::pair<int, double>, struct IterationError>;
 using SolutionMomentsPort = instrumentation::Port<system::moments::SphericalHarmonicI, struct SolutionMoments>;
 using ScatteringSourcePort = instrumentation::Port<dealii::Vector<double>, struct ScatteringSourcePortParameter>;
 using FissionSourcePort = instrumentation::Port<dealii::Vector<double>, struct FissionSourcePortParameter>;
-using ScalarFluxPort = instrumentation::Port<dealii::Vector<double>, struct ScalarFluxPortParameter>;
+using ScalarFluxPort = instrumentation::Port<GroupVectorMap, struct ScalarFluxPortParameter>;
 } // namespace data_names
 
 


### PR DESCRIPTION
This is an update to BART instrumentation.

Feature added: an instrument that will read `std::unordered_map<int, dealii::Vector<double>>` and output a VTU file that contains each entry in the map as a separate data field. This is appropriate for multi-group solves for values such as scalar flux and sources.

Updates:
- Adds instrumentation to group iteration to output scattering source using the new instrument. 
- Replaces existing data port instrumentation for outer iteration scalar flux and fission source using this new instrument.